### PR TITLE
Harden request scoping in the HTTP and MCP host APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+Host API scope hardening:
+
+- Every non-health HTTP route now runs the configured authentication,
+  including `/v1/trust_policy` and `/mcp`.
+- An authenticated `user_id` (from `auth_hook`) can no longer be
+  overridden by the JSON body, `X-ContextDB-User` header, query string,
+  or MCP tool arguments; a conflict is a clear 400 (`ScopeConflictError`)
+  instead of a silent pick.
+- `/mcp` propagates the authenticated scope into every tool call.
+- ID-based `confirm` / `forget` verify the target belongs to the resolved
+  user scope; a foreign `memory_id` raises `MemoryNotFoundError`,
+  indistinguishable from a missing one. Same guarantee on SQLite and
+  Postgres stores.
+- Anonymous loopback serving is unchanged and documented as *not* an
+  authorization boundary.
+
 Host-adoption work from serviceagent integration:
 
 - `contextdb serve --http` (`pycontextdb[serve]`) — JSON API + `/mcp`, Bearer token, `auth_hook`.

--- a/contextdb/__init__.py
+++ b/contextdb/__init__.py
@@ -12,8 +12,10 @@ from contextdb.core.exceptions import (
     ContextDBError,
     MemoryNotFoundError,
     PrivacyError,
+    ScopeConflictError,
     SourceRequiredError,
     StorageError,
+    UnauthorizedError,
 )
 from contextdb.core.models import (
     Edge,
@@ -48,9 +50,11 @@ __all__ = [
     "PIIType",
     "PrivacyError",
     "RetentionPolicy",
+    "ScopeConflictError",
     "SourceRequiredError",
     "StorageError",
     "TrustPolicy",
+    "UnauthorizedError",
     "__version__",
     "init",
     "utc_now",

--- a/contextdb/client.py
+++ b/contextdb/client.py
@@ -26,7 +26,12 @@ from typing import TYPE_CHECKING, Any
 
 from contextdb.core.clock import Clock, utc_now
 from contextdb.core.config import ContextDBConfig
-from contextdb.core.exceptions import ConfigError, ContextDBError, SourceRequiredError
+from contextdb.core.exceptions import (
+    ConfigError,
+    ContextDBError,
+    MemoryNotFoundError,
+    SourceRequiredError,
+)
 from contextdb.core.models import (
     EpistemicSource,
     MemoryExplanation,
@@ -742,6 +747,10 @@ class ContextDB:
         fact: ``confirmed=True``, first-party, high confidence, speaker
         added to ``corroborated_by``. Under any stock :class:`TrustPolicy`
         the fact then passes ``recall_for_action``.
+
+        With a resolved user scope, a ``memory_id`` owned by a different
+        user raises :class:`MemoryNotFoundError` — a request can never
+        confirm a known foreign memory.
         """
         uid = self._resolve_user(user_id)
         await self._ensure_init()
@@ -964,12 +973,22 @@ class ContextDB:
 
         ``memory_id`` deletes one row. ``entity`` + ``attribute`` deletes the
         current occupants of that slot (``forget my address``).
+
+        With a resolved user scope, a ``memory_id`` that belongs to a
+        different user raises :class:`MemoryNotFoundError` — a known foreign
+        id is rejected, never silently deleted or no-op'd. An unscoped
+        client (no user anywhere) keeps the legacy local behavior and is
+        not an authorization boundary.
         """
         uid = self._resolve_user(user_id)
         await self._ensure_init()
         store = self._require_store()
 
         if memory_id is not None:
+            if uid is not None:
+                target = await store.get_raw(memory_id)
+                if target is not None and target.user_id != uid:
+                    raise MemoryNotFoundError(memory_id)
             removed = await store.delete(memory_id, hard=True)
             count = 1 if removed else 0
             if removed and self._audit is not None:

--- a/contextdb/core/exceptions.py
+++ b/contextdb/core/exceptions.py
@@ -31,3 +31,20 @@ class ConfigError(ContextDBError):
 
 class SourceRequiredError(ConfigError):
     """Raised when a write omits epistemic ``source`` and the host requires it."""
+
+
+class UnauthorizedError(ContextDBError):
+    """Raised when a host API request fails configured authentication.
+
+    The HTTP layer maps this to 401; every other :class:`ContextDBError`
+    maps to 400.
+    """
+
+
+class ScopeConflictError(ContextDBError):
+    """Raised when a request carries a user scope that conflicts with the
+    authenticated scope (or two request-supplied scopes disagree).
+
+    Silently picking one of two conflicting scopes is how cross-user writes
+    happen, so the host APIs reject the request instead (HTTP 400).
+    """

--- a/contextdb/dynamics/trust.py
+++ b/contextdb/dynamics/trust.py
@@ -297,11 +297,16 @@ class TrustEngine:
         This is the writeback the verify-before-act loop was missing: the
         agent asked, the user said yes, and now the fact is trusted under
         any policy that honours ``confirmed``.
+
+        When ``user_id`` is supplied, the target must belong to that user;
+        a foreign id raises :class:`MemoryNotFoundError`, indistinguishable
+        from a missing one. ``user_id=None`` is the unscoped local/admin
+        context and is not an authorization boundary.
         """
         from contextdb.core.exceptions import MemoryNotFoundError
 
         item = await self.store.get_raw(memory_id)
-        if item is None:
+        if item is None or (user_id is not None and item.user_id != user_id):
             raise MemoryNotFoundError(memory_id)
         now = self.clock()
         speakers = list(item.corroborated_by)

--- a/contextdb/mcp.py
+++ b/contextdb/mcp.py
@@ -143,6 +143,7 @@ def _serialize(item: MemoryItem) -> dict[str, Any]:
     return {
         "id": item.id,
         "content": item.content,
+        "user_id": item.user_id,
         "epistemic_source": item.epistemic_source,
         "confidence": item.confidence,
         "corroboration_count": item.corroboration_count,

--- a/contextdb/serve.py
+++ b/contextdb/serve.py
@@ -9,17 +9,38 @@ Auth: set ``CONTEXTDB_SERVE_TOKEN`` or pass ``token=``. Requests must send
 ``Authorization: Bearer <token>``. Bind to a loopback address if you run
 without a token. Pass ``auth_hook`` to mint user/tenant from your own
 gateway headers.
+
+Scope rules (every route except ``/health`` / ``/v1/health``):
+
+* When ``auth_hook`` returns ``user_id``, that authenticated scope wins.
+  A conflicting ``user_id`` in the JSON body, the ``X-ContextDB-User``
+  header, the query string, or MCP tool arguments is rejected with 400 —
+  never silently selected.
+* ``/mcp`` injects the resolved scope into every tool call, so an
+  authenticated caller cannot recall, confirm, or forget another user's
+  memories through tool arguments.
+* ID-based ``confirm`` / ``forget`` verify the target belongs to the
+  resolved scope; a foreign id fails exactly like a missing one.
+* With no authenticated user (``allow_anonymous`` loopback), requests may
+  still pass ``user_id`` per call. That is a local convenience, NOT an
+  authorization boundary — see docs/multi_tenant.md.
 """
 
 from __future__ import annotations
 
 import inspect
 import os
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable
 from typing import Any
 
 from contextdb.client import ContextDB
-from contextdb.core.exceptions import ConfigError, ContextDBError, SourceRequiredError
+from contextdb.core.exceptions import (
+    ConfigError,
+    ContextDBError,
+    ScopeConflictError,
+    SourceRequiredError,
+    UnauthorizedError,
+)
 from contextdb.core.models import MemoryItem
 from contextdb.mcp import ContextDBMCPServer
 
@@ -49,6 +70,12 @@ def _json_response(status: int, payload: dict[str, Any]) -> Any:
     from starlette.responses import JSONResponse
 
     return JSONResponse(payload, status_code=status)
+
+
+def _error_response(exc: ContextDBError) -> Any:
+    """Map client-visible errors: 401 for auth failures, 400 otherwise."""
+    code = 401 if isinstance(exc, UnauthorizedError) else 400
+    return _json_response(code, {"error": str(exc)})
 
 
 async def _read_json(request: Any) -> dict[str, Any]:
@@ -96,7 +123,7 @@ def create_app(
         if resolved_token:
             auth = headers.get("authorization", "")
             if auth != f"Bearer {resolved_token}":
-                raise ConfigError("unauthorized")
+                raise UnauthorizedError("unauthorized")
         elif not allow_anonymous:
             raise ConfigError(
                 "Refusing anonymous HTTP. Set CONTEXTDB_SERVE_TOKEN, pass "
@@ -104,18 +131,71 @@ def create_app(
             )
         return {}
 
-    def _user_id(request: Request, body: dict[str, Any], auth: dict[str, Any]) -> str | None:
-        return (
-            (auth.get("user_id") if isinstance(auth.get("user_id"), str) else None)
-            or body.get("user_id")
-            or request.headers.get("x-contextdb-user")
-            or client.user_id
-        )
+    def _resolve_scope(
+        request: Request,
+        body: dict[str, Any],
+        auth: dict[str, Any],
+        *,
+        extra: Iterable[Any] = (),
+    ) -> str | None:
+        """Resolve the one user scope a request runs under.
+
+        An authenticated ``user_id`` (from ``auth_hook``) cannot be
+        overridden: a conflicting ``user_id`` in the JSON body, the
+        ``X-ContextDB-User`` header, the query string, or MCP tool
+        arguments raises :class:`ScopeConflictError` (400) instead of
+        silently selecting one. Without an authenticated user, the
+        request-supplied scopes must at least agree with each other.
+        Returns ``None`` for anonymous local usage, which is a convenience
+        for loopback deployments, not an authorization boundary.
+        """
+        auth_user_raw = auth.get("user_id")
+        auth_user = auth_user_raw if isinstance(auth_user_raw, str) and auth_user_raw else None
+
+        supplied: list[tuple[str, str]] = []
+
+        def _collect(where: str, value: Any) -> None:
+            if value is None:
+                return
+            if not isinstance(value, str) or not value:
+                raise ConfigError(f"user_id from {where} must be a non-empty string")
+            supplied.append((where, value))
+
+        _collect("JSON body", body.get("user_id"))
+        _collect("X-ContextDB-User header", request.headers.get("x-contextdb-user"))
+        _collect("query string", request.query_params.get("user_id"))
+        for value in extra:
+            _collect("tool arguments", value)
+
+        if auth_user is not None:
+            for where, value in supplied:
+                if value != auth_user:
+                    raise ScopeConflictError(
+                        f"user_id {value!r} from {where} conflicts with the "
+                        f"authenticated user {auth_user!r}. Drop the override "
+                        "or authenticate as that user."
+                    )
+            return auth_user
+        distinct = {value for _, value in supplied}
+        if len(distinct) > 1:
+            detail = ", ".join(f"{where}={value!r}" for where, value in supplied)
+            raise ScopeConflictError(
+                f"Conflicting user_id values in one request ({detail}). Send exactly one."
+            )
+        if distinct:
+            return next(iter(distinct))
+        return client.user_id
 
     async def health(_request: Request) -> Any:
         return _json_response(200, {"ok": True, "service": "contextdb"})
 
-    async def trust_policy(_request: Request) -> Any:
+    async def trust_policy(request: Request) -> Any:
+        # Not a health route: it runs the configured authentication like
+        # every other route.
+        try:
+            await _authorize(request, {})
+        except ContextDBError as exc:
+            return _error_response(exc)
         return _json_response(200, client.trust_policy.model_dump())
 
     async def remember(request: Request) -> Any:
@@ -126,7 +206,7 @@ def create_app(
                 raise SourceRequiredError(
                     "remember requires source: user_stated | agent_inferred | third_party"
                 )
-            uid = _user_id(request, body, auth)
+            uid = _resolve_scope(request, body, auth)
             item = await client.factual.add(
                 str(body["content"]),
                 source=body.get("source"),
@@ -140,28 +220,26 @@ def create_app(
         except SourceRequiredError as exc:
             return _json_response(400, {"error": str(exc)})
         except ContextDBError as exc:
-            code = 401 if str(exc) == "unauthorized" else 400
-            return _json_response(code, {"error": str(exc)})
+            return _error_response(exc)
 
     async def remember_many(request: Request) -> Any:
         body = await _read_json(request)
         try:
             auth = await _authorize(request, body)
-            uid = _user_id(request, body, auth)
+            uid = _resolve_scope(request, body, auth)
             items_in = body.get("items") or body.get("contents") or []
             if not isinstance(items_in, list):
                 raise ConfigError("items must be a list")
             stored = await client.factual.add_many(items_in, user_id=uid)
             return _json_response(200, {"memories": [_serialize(m) for m in stored]})
         except ContextDBError as exc:
-            code = 401 if str(exc) == "unauthorized" else 400
-            return _json_response(code, {"error": str(exc)})
+            return _error_response(exc)
 
     async def recall(request: Request) -> Any:
         body = await _read_json(request)
         try:
             auth = await _authorize(request, body)
-            uid = _user_id(request, body, auth)
+            uid = _resolve_scope(request, body, auth)
             items = await client.factual.recall(
                 str(body["query"]),
                 top_k=int(body.get("top_k", 5)),
@@ -182,14 +260,13 @@ def create_app(
                 },
             )
         except ContextDBError as exc:
-            code = 401 if str(exc) == "unauthorized" else 400
-            return _json_response(code, {"error": str(exc)})
+            return _error_response(exc)
 
     async def recall_for_action(request: Request) -> Any:
         body = await _read_json(request)
         try:
             auth = await _authorize(request, body)
-            uid = _user_id(request, body, auth)
+            uid = _resolve_scope(request, body, auth)
             items = await client.factual.recall_for_action(
                 str(body["query"]),
                 top_k=int(body.get("top_k", 5)),
@@ -197,36 +274,33 @@ def create_app(
             )
             return _json_response(200, {"memories": [_serialize(m) for m in items]})
         except ContextDBError as exc:
-            code = 401 if str(exc) == "unauthorized" else 400
-            return _json_response(code, {"error": str(exc)})
+            return _error_response(exc)
 
     async def confirm(request: Request) -> Any:
         body = await _read_json(request)
         try:
             auth = await _authorize(request, body)
-            uid = _user_id(request, body, auth)
+            uid = _resolve_scope(request, body, auth)
             item = await client.factual.confirm(str(body["memory_id"]), user_id=uid)
             return _json_response(200, {"memory": _serialize(item)})
         except ContextDBError as exc:
-            code = 401 if str(exc) == "unauthorized" else 400
-            return _json_response(code, {"error": str(exc)})
+            return _error_response(exc)
 
     async def pending(request: Request) -> Any:
         body = await _read_json(request) if request.method == "POST" else {}
         try:
             auth = await _authorize(request, body)
-            uid = _user_id(request, body, auth) or request.query_params.get("user_id")
+            uid = _resolve_scope(request, body, auth)
             items = await client.factual.pending_confirmations(user_id=uid)
             return _json_response(200, {"memories": [_serialize(m) for m in items]})
         except ContextDBError as exc:
-            code = 401 if str(exc) == "unauthorized" else 400
-            return _json_response(code, {"error": str(exc)})
+            return _error_response(exc)
 
     async def forget(request: Request) -> Any:
         body = await _read_json(request)
         try:
             auth = await _authorize(request, body)
-            uid = _user_id(request, body, auth)
+            uid = _resolve_scope(request, body, auth)
             if body.get("memory_id"):
                 deleted = await client.forget(
                     user_id=uid,
@@ -238,32 +312,36 @@ def create_app(
                     entity=str(body["entity"]),
                     attribute=str(body["attribute"]),
                 )
-            elif body.get("user_id") or uid:
-                target = str(body.get("user_id") or uid)
-                deleted = await client.forget_user(target)
-                verified = await client.verify_forgotten(target)
+            elif uid:
+                # Whole-user erasure targets the resolved scope only — the
+                # request body can never retarget it at another user.
+                deleted = await client.forget_user(uid)
+                verified = await client.verify_forgotten(uid)
                 return _json_response(200, {"deleted": deleted, "verified": verified})
             else:
                 raise ConfigError("forget requires memory_id, entity+attribute, or user_id")
             return _json_response(200, {"deleted": deleted})
         except ContextDBError as exc:
-            code = 401 if str(exc) == "unauthorized" else 400
-            return _json_response(code, {"error": str(exc)})
+            return _error_response(exc)
 
     async def mcp_call(request: Request) -> Any:
         """JSON-RPC-ish MCP tools/call for hosts that already speak MCP names."""
         body = await _read_json(request)
         try:
-            await _authorize(request, body)
+            auth = await _authorize(request, body)
             name = str(body.get("name") or body.get("method") or "")
             arguments = body.get("arguments") or body.get("params") or {}
             if not isinstance(arguments, dict):
                 raise ConfigError("arguments must be an object")
+            # The resolved scope is propagated into every tool call; a
+            # conflicting user_id inside the tool arguments is a 400.
+            uid = _resolve_scope(request, body, auth, extra=[arguments.get("user_id")])
+            if uid is not None:
+                arguments = {**arguments, "user_id": uid}
             result = await mcp.call_tool(name, arguments)
             return _json_response(200, result)
         except ContextDBError as exc:
-            code = 401 if str(exc) == "unauthorized" else 400
-            return _json_response(code, {"error": str(exc)})
+            return _error_response(exc)
 
     routes = [
         Route("/health", health, methods=["GET"]),

--- a/docs/api.md
+++ b/docs/api.md
@@ -33,6 +33,7 @@ async def search(query, top_k=10, memory_type=None, time_range=None,
                  min_confidence=None, include_third_party=True) -> list[MemoryItem]
     # Queries are PII-redacted before embed. compose hops sibling slots.
 async def confirm(memory_id, user_id=None) -> MemoryItem
+    # With a resolved user scope, a foreign memory_id raises MemoryNotFoundError.
 async def get(memory_id) -> MemoryItem | None
 async def update(memory_id, content=None, metadata=None) -> MemoryItem
 async def delete(memory_id, hard=False) -> None
@@ -42,6 +43,8 @@ async def add_fast_many(contents, *, user_id=None) -> list[MemoryItem]
 async def pending_confirmations(user_id=None, limit=100) -> list[MemoryItem]
 async def forget(user_id=None, entity=None, older_than=None, *,
                  memory_id=None, attribute=None) -> int
+    # A foreign memory_id under a resolved user scope raises
+    # MemoryNotFoundError; a missing one still returns 0.
 async def forget_user(user_id) -> int
 db.on(event, hook)  # write, recall, confirm, forget, injection_suspect, embed_fallback
 async def verify_forgotten(user_id) -> bool
@@ -85,6 +88,14 @@ async def get_entity(name) -> dict
 
 `MemoryItem`, `Edge`, `Entity`, `RetentionPolicy`, `PIIAnnotation`,
 `MemoryType`, `MemoryStatus`, `PIIType`, `TrustPolicy`, `MemoryExplanation`.
+
+## Errors
+
+`ContextDBError` is the base. `MemoryNotFoundError`, `StorageError`,
+`PrivacyError`, `ConfigError` (+ `SourceRequiredError`),
+`UnauthorizedError` (host API auth failed — HTTP 401), and
+`ScopeConflictError` (request scope disagrees with the authenticated
+scope — HTTP 400) derive from it.
 
 Load-bearing `MemoryItem` fields for the trust model: `epistemic_source`,
 `corroborated_by`, `confirmed`, `contested`, `action_relevant`,

--- a/docs/multi_tenant.md
+++ b/docs/multi_tenant.md
@@ -19,7 +19,28 @@ Isolation is the same SQL `user_id = ?` predicate a scoped client uses.
 A scoped client still cannot be widened — `init(user_id="alice")` then
 `recall(..., user_id="bob")` raises.
 
-HTTP: omit `user_id` at `init()` and send `X-ContextDB-User` per request.
+HTTP: omit `user_id` at `init()` and authenticate each request — the
+resolved scope comes from `auth_hook` (or, for token-only deployments,
+`X-ContextDB-User` / the JSON body). See [serve.md](serve.md#request-scoping).
+
+## What is (and is not) an authorization boundary
+
+A **scoped client** (`init(user_id=...)`) is a boundary: the store
+refuses every other user's rows, and ID-based `confirm` / `forget`
+reject a foreign `memory_id` as if it did not exist.
+
+A **shared unscoped client with per-call `user_id=`** is a *scoping
+convenience* for trusted, in-process code. It keeps users' rows apart,
+but nothing stops the caller from passing a different `user_id` on the
+next call — do not expose it to untrusted input directly. The
+authorization boundary for remote callers is the HTTP/MCP layer
+(`create_app` with a token or `auth_hook`), which authenticates the
+request, pins the scope, and rejects conflicts with a 400.
+
+Likewise, running the HTTP server anonymously on loopback is local
+convenience only — **not** an authorization boundary. Any local process
+can claim any `user_id`. Bind non-loopback only behind a token or an
+`auth_hook`.
 
 ## If you cannot change call sites: `ContextDBPool`
 

--- a/docs/serve.md
+++ b/docs/serve.md
@@ -25,18 +25,40 @@ Without a token the server only binds loopback. Non-loopback requires
 
 | Method | Path | Notes |
 |---|---|---|
-| GET | `/health` | liveness |
-| GET | `/v1/trust_policy` | active policy constants |
+| GET | `/health` | liveness — the only unauthenticated route |
+| GET | `/v1/trust_policy` | active policy constants; **requires auth when auth is configured** |
 | POST | `/v1/remember` | **requires** `source` (400 if omitted) |
 | POST | `/v1/remember_many` | LLM-free batch |
 | POST | `/v1/recall` | demoted context + memories |
 | POST | `/v1/recall_for_action` | empty list if nothing is trusted |
-| POST | `/v1/confirm` | user said yes |
+| POST | `/v1/confirm` | user said yes; foreign `memory_id` → 400 |
 | GET/POST | `/v1/pending_confirmations` | facts waiting on a yes |
-| POST | `/v1/forget` | `memory_id` / `entity`+`attribute` / `user_id` |
-| POST | `/mcp` | same tool names as stdio MCP |
+| POST | `/v1/forget` | `memory_id` / `entity`+`attribute` / whole resolved user |
+| POST | `/mcp` | same tool names as stdio MCP; runs in the authenticated scope |
+
+Every route except `/health` (and its alias `/v1/health`) runs the
+configured authentication — token and/or `auth_hook` — including
+`/v1/trust_policy` and `/mcp`.
+
+## Request scoping
 
 Send `X-ContextDB-User` or `"user_id"` in the JSON body. `Authorization: Bearer <token>` when a token is configured.
+
+When `auth_hook` returns a `user_id`, that authenticated scope **wins**:
+a conflicting `user_id` in the JSON body, the `X-ContextDB-User` header,
+the query string, or MCP tool arguments is rejected with `400`
+(`ScopeConflictError`) — the server never silently picks one scope over
+another. A matching `user_id` is accepted; an absent one means the
+request runs as the authenticated user.
+
+`/mcp` propagates the resolved scope into every tool call, so an
+authenticated caller cannot recall, confirm, or forget another user's
+memories by passing their `user_id` in tool arguments.
+
+ID-based `confirm` and `forget` verify the target belongs to the resolved
+scope. A `memory_id` owned by a different user fails with `400`, exactly
+like an unknown id — a request can never read, confirm, or delete a known
+foreign memory.
 
 ```python
 from contextdb.serve import create_app
@@ -50,3 +72,12 @@ app = create_app(db, token="...", auth_hook=from_gateway)
 `/mcp` is JSON `{ "name": "remember", "arguments": {...} }`, not a full
 MCP session. Use it from any HTTP client. A streamable-HTTP MCP transport
 can sit in front of the same `ContextDBMCPServer.call_tool` surface.
+
+## Anonymous loopback is not an authorization boundary
+
+`allow_anonymous=True` (or `serve_http` on a loopback address with no
+token) exists for local, single-tenant development: requests may pass any
+`user_id` per call, or none at all. **Nothing authenticates or isolates
+those callers** — any process that can reach the port can read, confirm,
+or delete any user's memories. Never expose an anonymous server beyond
+loopback; put a token or an `auth_hook` in front of anything else.

--- a/tests/pg_util.py
+++ b/tests/pg_util.py
@@ -1,0 +1,48 @@
+"""Helpers for tests that need a real Postgres server.
+
+Set ``CONTEXTDB_TEST_POSTGRES_URL`` to a database the test user may create
+and drop databases on (the tests create a fresh database each, because the
+hash-chained audit log is global to a database — a shared test database
+would accumulate entries and fail whole-chain verification).
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import pytest
+
+
+def postgres_base_url() -> str:
+    url = os.environ.get("CONTEXTDB_TEST_POSTGRES_URL")
+    if not url:
+        pytest.skip("set CONTEXTDB_TEST_POSTGRES_URL to run Postgres tests")
+    return url
+
+
+@asynccontextmanager
+async def fresh_pg_database() -> AsyncIterator[str]:
+    """Yield a URL for a freshly-created database; dropped on exit."""
+    base = postgres_base_url()
+    try:
+        import asyncpg
+    except ImportError:
+        pytest.skip("asyncpg not installed (pip install 'pycontextdb[postgres]')")
+    name = f"contextdb_test_{uuid.uuid4().hex[:12]}"
+    conn = await asyncpg.connect(base)
+    try:
+        await conn.execute(f'CREATE DATABASE "{name}"')
+    finally:
+        await conn.close()
+    url = f"{base.rsplit('/', 1)[0]}/{name}"
+    try:
+        yield url
+    finally:
+        drop = await asyncpg.connect(base)
+        try:
+            await drop.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+        finally:
+            await drop.close()

--- a/tests/unit/test_host_api.py
+++ b/tests/unit/test_host_api.py
@@ -8,7 +8,11 @@ import pytest
 
 import contextdb
 from contextdb.core.config import ContextDBConfig
-from contextdb.core.exceptions import ConfigError, SourceRequiredError
+from contextdb.core.exceptions import (
+    ConfigError,
+    MemoryNotFoundError,
+    SourceRequiredError,
+)
 from contextdb.pool import ContextDBPool
 
 
@@ -134,6 +138,70 @@ async def test_add_many_and_recall_filters(tmp_path: Path) -> None:
         hits = await db.factual.recall("email", entity="caller", min_confidence=0.8)
         assert hits
         assert all(h.entity_key == "caller" for h in hits)
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_confirm_rejects_foreign_memory_id(tmp_path: Path) -> None:
+    """A shared client must never confirm a known foreign memory ID."""
+    db = contextdb.init(config=_cfg(tmp_path))
+    try:
+        item = await db.factual.add(
+            "Alice PIN is 7788",
+            source="user_stated",
+            confidence=0.5,
+            action_relevant=True,
+            entity="account",
+            attribute="pin",
+            user_id="alice",
+        )
+        with pytest.raises(MemoryNotFoundError):
+            await db.factual.confirm(item.id, user_id="bob")
+        still = await db.get(item.id)
+        assert still is not None
+        assert still.confirmed is False
+
+        confirmed = await db.factual.confirm(item.id, user_id="alice")
+        assert confirmed.confirmed is True
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_forget_rejects_foreign_memory_id(tmp_path: Path) -> None:
+    """A shared client must never delete a known foreign memory ID — and a
+    missing id keeps the legacy ``0`` return."""
+    db = contextdb.init(config=_cfg(tmp_path))
+    try:
+        item = await db.factual.add(
+            "Alice PIN is 7788", source="user_stated", user_id="alice"
+        )
+        with pytest.raises(MemoryNotFoundError):
+            await db.forget(user_id="bob", memory_id=item.id)
+        assert await db.get(item.id) is not None
+
+        assert await db.forget(user_id="bob", memory_id="no-such-id") == 0
+        assert await db.forget(user_id="alice", memory_id=item.id) == 1
+        assert await db.get(item.id) is None
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_unscoped_local_usage_has_no_scope_checks(tmp_path: Path) -> None:
+    """No user anywhere: confirm/forget by id work as before. This local
+    usage is documented as NOT an authorization boundary."""
+    db = contextdb.init(config=_cfg(tmp_path))
+    try:
+        item = await db.factual.add(
+            "local fact", source="user_stated", confidence=0.5, action_relevant=True
+        )
+        assert item.user_id is None
+        confirmed = await db.factual.confirm(item.id)
+        assert confirmed.confirmed is True
+        assert await db.forget(memory_id=item.id) == 1
+        assert await db.get(item.id) is None
     finally:
         await db.close()
 

--- a/tests/unit/test_scoped_id_access.py
+++ b/tests/unit/test_scoped_id_access.py
@@ -1,0 +1,135 @@
+"""Foreign memory IDs must be rejected identically on every store backend.
+
+The ownership checks for ID-based confirm/forget live in the client and
+trust layers above the store, so the same tests run against SQLite always,
+and against Postgres when ``CONTEXTDB_TEST_POSTGRES_URL`` points at a test
+database (CI without Postgres skips those parametrizations).
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+
+import contextdb
+from contextdb.core.config import ContextDBConfig
+from contextdb.core.exceptions import MemoryNotFoundError
+from contextdb.store.factory import open_store
+
+_PG_URL = os.environ.get("CONTEXTDB_TEST_POSTGRES_URL")
+
+_BACKENDS = ["sqlite", "postgres"]
+
+
+def _storage_url(backend: str, tmp_path: Path) -> str:
+    if backend == "postgres":
+        if not _PG_URL:
+            pytest.skip("set CONTEXTDB_TEST_POSTGRES_URL to run Postgres store tests")
+        return _PG_URL
+    return f"sqlite:///{tmp_path}/scoped-{uuid.uuid4().hex}.db"
+
+
+def _cfg(backend: str, tmp_path: Path, storage_url: str | None = None) -> ContextDBConfig:
+    return ContextDBConfig(
+        storage_url=storage_url or _storage_url(backend, tmp_path),
+        embedding_model="mock",
+        embedding_dim=32,
+        llm_model="mock",
+        llm_api_key="mock",
+        enable_entity_graph=False,
+        enable_multi_graph=False,
+        enable_auto_link=False,
+        enable_audit=True,
+    )
+
+
+def _user(role: str) -> str:
+    """Unique user ids keep a shared Postgres database isolated per test."""
+    return f"{role}-{uuid.uuid4().hex}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", _BACKENDS)
+async def test_confirm_rejects_foreign_memory_id_on_store(
+    backend: str, tmp_path: Path
+) -> None:
+    alice, bob = _user("alice"), _user("bob")
+    db = contextdb.init(config=_cfg(backend, tmp_path))
+    try:
+        item = await db.factual.add(
+            "Alice PIN is 7788",
+            source="user_stated",
+            confidence=0.5,
+            action_relevant=True,
+            entity="account",
+            attribute="pin",
+            user_id=alice,
+        )
+        with pytest.raises(MemoryNotFoundError):
+            await db.factual.confirm(item.id, user_id=bob)
+        still = await db.get(item.id)
+        assert still is not None
+        assert still.confirmed is False
+
+        confirmed = await db.factual.confirm(item.id, user_id=alice)
+        assert confirmed.confirmed is True
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", _BACKENDS)
+async def test_forget_rejects_foreign_memory_id_on_store(
+    backend: str, tmp_path: Path
+) -> None:
+    alice, bob = _user("alice"), _user("bob")
+    db = contextdb.init(config=_cfg(backend, tmp_path))
+    try:
+        item = await db.factual.add(
+            "Alice PIN is 7788", source="user_stated", user_id=alice
+        )
+        with pytest.raises(MemoryNotFoundError):
+            await db.forget(user_id=bob, memory_id=item.id)
+        assert await db.get(item.id) is not None
+
+        assert await db.forget(user_id=bob, memory_id="no-such-id") == 0
+        assert await db.forget(user_id=alice, memory_id=item.id) == 1
+        assert await db.get(item.id) is None
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", _BACKENDS)
+async def test_scoped_store_hides_foreign_ids(backend: str, tmp_path: Path) -> None:
+    """Store-level guarantee under the client checks: a scoped store cannot
+    see or delete another user's row; an unscoped store can — which is what
+    lets the client reject a known foreign id instead of deleting it."""
+    alice, bob = _user("alice"), _user("bob")
+    url = _storage_url(backend, tmp_path)
+    db = contextdb.init(config=_cfg(backend, tmp_path, storage_url=url))
+    try:
+        item = await db.factual.add("bob secret", source="user_stated", user_id=bob)
+    finally:
+        await db.close()
+
+    scoped = open_store(url, user_id=alice, embedding_dim=32)
+    await scoped.initialize()
+    try:
+        assert await scoped.get(item.id) is None
+        assert await scoped.get_raw(item.id) is None
+        assert await scoped.delete(item.id, hard=True) is False
+    finally:
+        await scoped.close()
+
+    unscoped = open_store(url, embedding_dim=32)
+    await unscoped.initialize()
+    try:
+        seen = await unscoped.get_raw(item.id)
+        assert seen is not None
+        assert seen.user_id == bob
+    finally:
+        await unscoped.close()

--- a/tests/unit/test_scoped_id_access.py
+++ b/tests/unit/test_scoped_id_access.py
@@ -3,13 +3,16 @@
 The ownership checks for ID-based confirm/forget live in the client and
 trust layers above the store, so the same tests run against SQLite always,
 and against Postgres when ``CONTEXTDB_TEST_POSTGRES_URL`` points at a test
-database (CI without Postgres skips those parametrizations).
+database (CI without Postgres skips those parametrizations). Postgres
+tests get a fresh database each — a shared test database accumulates rows
+from other suites and breaks isolation.
 """
 
 from __future__ import annotations
 
-import os
 import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
@@ -18,23 +21,23 @@ import contextdb
 from contextdb.core.config import ContextDBConfig
 from contextdb.core.exceptions import MemoryNotFoundError
 from contextdb.store.factory import open_store
-
-_PG_URL = os.environ.get("CONTEXTDB_TEST_POSTGRES_URL")
+from tests.pg_util import fresh_pg_database
 
 _BACKENDS = ["sqlite", "postgres"]
 
 
-def _storage_url(backend: str, tmp_path: Path) -> str:
+@asynccontextmanager
+async def _db_url(backend: str, tmp_path: Path) -> AsyncIterator[str]:
     if backend == "postgres":
-        if not _PG_URL:
-            pytest.skip("set CONTEXTDB_TEST_POSTGRES_URL to run Postgres store tests")
-        return _PG_URL
-    return f"sqlite:///{tmp_path}/scoped-{uuid.uuid4().hex}.db"
+        async with fresh_pg_database() as url:
+            yield url
+    else:
+        yield f"sqlite:///{tmp_path}/scoped-{uuid.uuid4().hex}.db"
 
 
-def _cfg(backend: str, tmp_path: Path, storage_url: str | None = None) -> ContextDBConfig:
+def _cfg(storage_url: str) -> ContextDBConfig:
     return ContextDBConfig(
-        storage_url=storage_url or _storage_url(backend, tmp_path),
+        storage_url=storage_url,
         embedding_model="mock",
         embedding_dim=32,
         llm_model="mock",
@@ -47,7 +50,7 @@ def _cfg(backend: str, tmp_path: Path, storage_url: str | None = None) -> Contex
 
 
 def _user(role: str) -> str:
-    """Unique user ids keep a shared Postgres database isolated per test."""
+    """Unique user ids keep tests isolated from each other."""
     return f"{role}-{uuid.uuid4().hex}"
 
 
@@ -56,28 +59,29 @@ def _user(role: str) -> str:
 async def test_confirm_rejects_foreign_memory_id_on_store(
     backend: str, tmp_path: Path
 ) -> None:
-    alice, bob = _user("alice"), _user("bob")
-    db = contextdb.init(config=_cfg(backend, tmp_path))
-    try:
-        item = await db.factual.add(
-            "Alice PIN is 7788",
-            source="user_stated",
-            confidence=0.5,
-            action_relevant=True,
-            entity="account",
-            attribute="pin",
-            user_id=alice,
-        )
-        with pytest.raises(MemoryNotFoundError):
-            await db.factual.confirm(item.id, user_id=bob)
-        still = await db.get(item.id)
-        assert still is not None
-        assert still.confirmed is False
+    async with _db_url(backend, tmp_path) as url:
+        alice, bob = _user("alice"), _user("bob")
+        db = contextdb.init(config=_cfg(url))
+        try:
+            item = await db.factual.add(
+                "Alice PIN is 7788",
+                source="user_stated",
+                confidence=0.5,
+                action_relevant=True,
+                entity="account",
+                attribute="pin",
+                user_id=alice,
+            )
+            with pytest.raises(MemoryNotFoundError):
+                await db.factual.confirm(item.id, user_id=bob)
+            still = await db.get(item.id)
+            assert still is not None
+            assert still.confirmed is False
 
-        confirmed = await db.factual.confirm(item.id, user_id=alice)
-        assert confirmed.confirmed is True
-    finally:
-        await db.close()
+            confirmed = await db.factual.confirm(item.id, user_id=alice)
+            assert confirmed.confirmed is True
+        finally:
+            await db.close()
 
 
 @pytest.mark.asyncio
@@ -85,21 +89,22 @@ async def test_confirm_rejects_foreign_memory_id_on_store(
 async def test_forget_rejects_foreign_memory_id_on_store(
     backend: str, tmp_path: Path
 ) -> None:
-    alice, bob = _user("alice"), _user("bob")
-    db = contextdb.init(config=_cfg(backend, tmp_path))
-    try:
-        item = await db.factual.add(
-            "Alice PIN is 7788", source="user_stated", user_id=alice
-        )
-        with pytest.raises(MemoryNotFoundError):
-            await db.forget(user_id=bob, memory_id=item.id)
-        assert await db.get(item.id) is not None
+    async with _db_url(backend, tmp_path) as url:
+        alice, bob = _user("alice"), _user("bob")
+        db = contextdb.init(config=_cfg(url))
+        try:
+            item = await db.factual.add(
+                "Alice PIN is 7788", source="user_stated", user_id=alice
+            )
+            with pytest.raises(MemoryNotFoundError):
+                await db.forget(user_id=bob, memory_id=item.id)
+            assert await db.get(item.id) is not None
 
-        assert await db.forget(user_id=bob, memory_id="no-such-id") == 0
-        assert await db.forget(user_id=alice, memory_id=item.id) == 1
-        assert await db.get(item.id) is None
-    finally:
-        await db.close()
+            assert await db.forget(user_id=bob, memory_id="no-such-id") == 0
+            assert await db.forget(user_id=alice, memory_id=item.id) == 1
+            assert await db.get(item.id) is None
+        finally:
+            await db.close()
 
 
 @pytest.mark.asyncio
@@ -108,28 +113,28 @@ async def test_scoped_store_hides_foreign_ids(backend: str, tmp_path: Path) -> N
     """Store-level guarantee under the client checks: a scoped store cannot
     see or delete another user's row; an unscoped store can — which is what
     lets the client reject a known foreign id instead of deleting it."""
-    alice, bob = _user("alice"), _user("bob")
-    url = _storage_url(backend, tmp_path)
-    db = contextdb.init(config=_cfg(backend, tmp_path, storage_url=url))
-    try:
-        item = await db.factual.add("bob secret", source="user_stated", user_id=bob)
-    finally:
-        await db.close()
+    async with _db_url(backend, tmp_path) as url:
+        alice, bob = _user("alice"), _user("bob")
+        db = contextdb.init(config=_cfg(url))
+        try:
+            item = await db.factual.add("bob secret", source="user_stated", user_id=bob)
+        finally:
+            await db.close()
 
-    scoped = open_store(url, user_id=alice, embedding_dim=32)
-    await scoped.initialize()
-    try:
-        assert await scoped.get(item.id) is None
-        assert await scoped.get_raw(item.id) is None
-        assert await scoped.delete(item.id, hard=True) is False
-    finally:
-        await scoped.close()
+        scoped = open_store(url, user_id=alice, embedding_dim=32)
+        await scoped.initialize()
+        try:
+            assert await scoped.get(item.id) is None
+            assert await scoped.get_raw(item.id) is None
+            assert await scoped.delete(item.id, hard=True) is False
+        finally:
+            await scoped.close()
 
-    unscoped = open_store(url, embedding_dim=32)
-    await unscoped.initialize()
-    try:
-        seen = await unscoped.get_raw(item.id)
-        assert seen is not None
-        assert seen.user_id == bob
-    finally:
-        await unscoped.close()
+        unscoped = open_store(url, embedding_dim=32)
+        await unscoped.initialize()
+        try:
+            seen = await unscoped.get_raw(item.id)
+            assert seen is not None
+            assert seen.user_id == bob
+        finally:
+            await unscoped.close()

--- a/tests/unit/test_serve.py
+++ b/tests/unit/test_serve.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 import contextdb
 from contextdb.core.config import ContextDBConfig
+from contextdb.core.exceptions import UnauthorizedError
 from contextdb.serve import create_app
 
+httpx = pytest.importorskip("httpx")
+pytest.importorskip("starlette")
 
-def _cfg(tmp_path: Path) -> ContextDBConfig:
+
+def _cfg(tmp_path: Path, name: str = "serve.db") -> ContextDBConfig:
     return ContextDBConfig(
-        storage_url=f"sqlite:///{tmp_path}/serve.db",
+        storage_url=f"sqlite:///{tmp_path}/{name}",
         embedding_model="mock",
         embedding_dim=32,
         llm_model="mock",
@@ -22,16 +27,18 @@ def _cfg(tmp_path: Path) -> ContextDBConfig:
     )
 
 
+def _http_client(app: Any) -> Any:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://t"
+    )
+
+
 @pytest.mark.asyncio
 async def test_http_remember_requires_source_and_scopes_user(tmp_path: Path) -> None:
-    httpx = pytest.importorskip("httpx")
-    pytest.importorskip("starlette")
-    from httpx import ASGITransport, AsyncClient
-
     db = contextdb.init(config=_cfg(tmp_path))
     app = create_app(db, token="secret")
     try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        async with _http_client(app) as client:
             denied = await client.post("/v1/remember", json={"content": "x"})
             assert denied.status_code == 401
             missing = await client.post(
@@ -60,4 +67,303 @@ async def test_http_remember_requires_source_and_scopes_user(tmp_path: Path) -> 
             assert pending.status_code == 200
     finally:
         await db.close()
-        del httpx
+
+
+@pytest.mark.asyncio
+async def test_non_health_routes_require_configured_auth(tmp_path: Path) -> None:
+    """Every route except /health runs authentication when it is configured —
+    including /v1/trust_policy and /mcp."""
+    db = contextdb.init(config=_cfg(tmp_path))
+    app = create_app(db, token="secret")
+    try:
+        async with _http_client(app) as client:
+            assert (await client.get("/health")).status_code == 200
+            assert (await client.get("/v1/health")).status_code == 200
+
+            denied_policy = await client.get("/v1/trust_policy")
+            assert denied_policy.status_code == 401
+            denied_mcp = await client.post(
+                "/mcp", json={"name": "recall", "arguments": {"query": "x"}}
+            )
+            assert denied_mcp.status_code == 401
+
+            auth = {"Authorization": "Bearer secret"}
+            ok_policy = await client.get("/v1/trust_policy", headers=auth)
+            assert ok_policy.status_code == 200
+            assert "relevance_floor" in ok_policy.json()
+            ok_mcp = await client.post(
+                "/mcp",
+                headers=auth,
+                json={"name": "recall", "arguments": {"query": "x"}},
+            )
+            assert ok_mcp.status_code == 200
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_trust_policy_requires_auth_with_auth_hook(tmp_path: Path) -> None:
+    def hook(headers: dict[str, str], body: dict[str, Any]) -> dict[str, Any]:
+        user = headers.get("x-user-id")
+        if not user:
+            raise UnauthorizedError("unauthorized")
+        return {"user_id": user}
+
+    db = contextdb.init(config=_cfg(tmp_path))
+    app = create_app(db, auth_hook=hook)
+    try:
+        async with _http_client(app) as client:
+            assert (await client.get("/v1/trust_policy")).status_code == 401
+            ok = await client.get("/v1/trust_policy", headers={"X-User-Id": "alice"})
+            assert ok.status_code == 200
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_auth_hook_user_cannot_be_overridden(tmp_path: Path) -> None:
+    """JSON body, headers, and query string must not override the
+    authenticated user; a conflict is a clear 400, not a silent pick."""
+
+    def hook(headers: dict[str, str], body: dict[str, Any]) -> dict[str, Any]:
+        return {"user_id": "alice"}
+
+    db = contextdb.init(config=_cfg(tmp_path))
+    app = create_app(db, auth_hook=hook)
+    try:
+        async with _http_client(app) as client:
+            by_body = await client.post(
+                "/v1/remember",
+                json={"content": "x", "source": "user_stated", "user_id": "bob"},
+            )
+            assert by_body.status_code == 400
+            assert "conflict" in by_body.json()["error"].lower()
+
+            by_header = await client.post(
+                "/v1/remember",
+                headers={"X-ContextDB-User": "bob"},
+                json={"content": "x", "source": "user_stated"},
+            )
+            assert by_header.status_code == 400
+
+            by_query = await client.post(
+                "/v1/recall?user_id=bob", json={"query": "x"}
+            )
+            assert by_query.status_code == 400
+
+            by_tool_args = await client.post(
+                "/mcp",
+                json={"name": "recall", "arguments": {"query": "x", "user_id": "bob"}},
+            )
+            assert by_tool_args.status_code == 400
+
+            # Whole-user erasure cannot be retargeted by the body either.
+            retarget = await client.post("/v1/forget", json={"user_id": "bob"})
+            assert retarget.status_code == 400
+
+            # No override: the request runs as the authenticated user.
+            ok = await client.post(
+                "/v1/remember",
+                json={"content": "alice fact", "source": "user_stated"},
+            )
+            assert ok.status_code == 200
+            assert ok.json()["memory"]["user_id"] == "alice"
+
+            # A matching user_id is not a conflict.
+            matching = await client.post(
+                "/v1/remember",
+                json={
+                    "content": "alice fact 2",
+                    "source": "user_stated",
+                    "user_id": "alice",
+                },
+            )
+            assert matching.status_code == 200
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_conflicting_request_scopes_rejected_without_auth_user(
+    tmp_path: Path,
+) -> None:
+    """Token auth authenticates the service, not a user: two disagreeing
+    request-supplied scopes are still a 400, never a silent pick."""
+    db = contextdb.init(config=_cfg(tmp_path))
+    app = create_app(db, token="secret")
+    try:
+        async with _http_client(app) as client:
+            conflict = await client.post(
+                "/v1/remember",
+                headers={"Authorization": "Bearer secret", "X-ContextDB-User": "u1"},
+                json={"content": "x", "source": "user_stated", "user_id": "u2"},
+            )
+            assert conflict.status_code == 400
+            agree = await client.post(
+                "/v1/remember",
+                headers={"Authorization": "Bearer secret", "X-ContextDB-User": "u1"},
+                json={"content": "x", "source": "user_stated", "user_id": "u1"},
+            )
+            assert agree.status_code == 200
+            assert agree.json()["memory"]["user_id"] == "u1"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_mcp_cannot_cross_user_scope(tmp_path: Path) -> None:
+    """/mcp propagates the authenticated scope into every tool call: an
+    authenticated caller cannot recall, confirm, or forget another user's
+    memory through tool arguments."""
+
+    def hook(headers: dict[str, str], body: dict[str, Any]) -> dict[str, Any]:
+        return {"user_id": "alice"}
+
+    db = contextdb.init(config=_cfg(tmp_path))
+    app = create_app(db, auth_hook=hook)
+    try:
+        bob_item = await db.factual.add(
+            "Bob likes green", source="user_stated", user_id="bob"
+        )
+        async with _http_client(app) as client:
+            remembered = await client.post(
+                "/mcp",
+                json={
+                    "name": "remember",
+                    "arguments": {
+                        "content": "Alice PIN is 7788",
+                        "source": "user_stated",
+                    },
+                },
+            )
+            assert remembered.status_code == 200
+            assert remembered.json()["memory"]["user_id"] == "alice"
+
+            # Recall runs as alice: bob's memory is never returned, even
+            # though the query targets it.
+            recalled = await client.post(
+                "/mcp", json={"name": "recall", "arguments": {"query": "green"}}
+            )
+            assert recalled.status_code == 200
+            hits = recalled.json()["memories"]
+            assert all(m["user_id"] == "alice" for m in hits)
+            assert all("green" not in m["content"] for m in hits)
+
+            # Tool arguments cannot override the authenticated scope.
+            override = await client.post(
+                "/mcp",
+                json={
+                    "name": "recall",
+                    "arguments": {"query": "green", "user_id": "bob"},
+                },
+            )
+            assert override.status_code == 400
+
+            # ID-based tools reject bob's memory id when running as alice.
+            foreign_confirm = await client.post(
+                "/mcp",
+                json={"name": "confirm", "arguments": {"memory_id": bob_item.id}},
+            )
+            assert foreign_confirm.status_code == 400
+            foreign_forget = await client.post(
+                "/mcp",
+                json={"name": "forget", "arguments": {"memory_id": bob_item.id}},
+            )
+            assert foreign_forget.status_code == 400
+
+        still = await db.get(bob_item.id)
+        assert still is not None
+        assert still.confirmed is False
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_confirm_and_forget_reject_foreign_memory_id(tmp_path: Path) -> None:
+    """A request must never confirm or delete a known foreign memory ID."""
+    db = contextdb.init(config=_cfg(tmp_path))
+    app = create_app(db, token="secret")
+    try:
+        alice_item = await db.factual.add(
+            "Alice PIN is 7788",
+            source="user_stated",
+            confidence=0.5,
+            action_relevant=True,
+            entity="account",
+            attribute="pin",
+            user_id="alice",
+        )
+        as_bob = {"Authorization": "Bearer secret", "X-ContextDB-User": "bob"}
+        as_alice = {"Authorization": "Bearer secret", "X-ContextDB-User": "alice"}
+        async with _http_client(app) as client:
+            confirm = await client.post(
+                "/v1/confirm", headers=as_bob, json={"memory_id": alice_item.id}
+            )
+            assert confirm.status_code == 400
+            still = await db.get(alice_item.id)
+            assert still is not None
+            assert still.confirmed is False
+
+            forget = await client.post(
+                "/v1/forget", headers=as_bob, json={"memory_id": alice_item.id}
+            )
+            assert forget.status_code == 400
+            assert await db.get(alice_item.id) is not None
+
+            ok_confirm = await client.post(
+                "/v1/confirm", headers=as_alice, json={"memory_id": alice_item.id}
+            )
+            assert ok_confirm.status_code == 200
+            assert ok_confirm.json()["memory"]["confirmed"] is True
+
+            ok_forget = await client.post(
+                "/v1/forget", headers=as_alice, json={"memory_id": alice_item.id}
+            )
+            assert ok_forget.status_code == 200
+            assert ok_forget.json()["deleted"] == 1
+            assert await db.get(alice_item.id) is None
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_anonymous_loopback_behavior_unchanged(tmp_path: Path) -> None:
+    """No configured auth + allow_anonymous: unscoped local usage still works.
+    This is a convenience for loopback deployments, not an authorization
+    boundary (see docs/multi_tenant.md)."""
+    db = contextdb.init(config=_cfg(tmp_path))
+    app = create_app(db, allow_anonymous=True)
+    try:
+        async with _http_client(app) as client:
+            remembered = await client.post(
+                "/v1/remember",
+                json={"content": "local loopback fact", "source": "user_stated"},
+            )
+            assert remembered.status_code == 200
+            assert remembered.json()["memory"]["user_id"] is None
+            mid = remembered.json()["memory"]["id"]
+
+            recalled = await client.post("/v1/recall", json={"query": "loopback"})
+            assert recalled.status_code == 200
+            assert any(m["id"] == mid for m in recalled.json()["memories"])
+
+            confirmed = await client.post("/v1/confirm", json={"memory_id": mid})
+            assert confirmed.status_code == 200
+
+            forgotten = await client.post("/v1/forget", json={"memory_id": mid})
+            assert forgotten.status_code == 200
+            assert forgotten.json()["deleted"] == 1
+
+            # Per-call user_id remains available without auth (documented
+            # convenience — anyone who can reach the port can claim it).
+            scoped = await client.post(
+                "/v1/remember",
+                headers={"X-ContextDB-User": "u1"},
+                json={"content": "u1 fact", "source": "user_stated"},
+            )
+            assert scoped.status_code == 200
+            assert scoped.json()["memory"]["user_id"] == "u1"
+
+            assert (await client.get("/v1/trust_policy")).status_code == 200
+    finally:
+        await db.close()


### PR DESCRIPTION
## Summary

<!-- What changed, and why. Evals win over prose. -->

## Open-core checklist

- [ ] I have read OPEN_CORE.md. This PR does not add cloud, billing, SSO, or entitlement code to the Apache tree.
- [ ] The SDK still does not import `contextdb_cloud` or any cloud control plane.
- [ ] No new local paid / license-key / entitlement boolean.
- [ ] Substantial contribution: I agree to the CLA in CONTRIBUTING.md (legal name and email in this description). Trivial typo PRs may skip this.
- [ ] `pytest tests/evals/ -v` and `python scripts/check_open_core.py` pass, or I explain why not.
