### PR TITLE
Allow hosts to share Postgres pools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,42 @@ jobs:
 
       - name: Run tests
         run: pytest
+
+  postgres:
+    name: Postgres integration
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      CONTEXTDB_TEST_POSTGRES_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install package with Postgres support
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,postgres]"
+
+      - name: Run real Postgres tests
+        run: |
+          pytest \
+            tests/unit/test_postgres_concurrency.py \
+            tests/unit/test_scoped_id_access.py \
+            tests/unit/test_vector_scope.py

--- a/contextdb/__init__.py
+++ b/contextdb/__init__.py
@@ -70,6 +70,7 @@ def init(
     session_id: str | None = None,
     clock: Clock | None = None,
     trust_policy: TrustPolicy | None = None,
+    postgres_pool: Any | None = None,
     **kwargs: Any,
 ) -> ContextDB:
     """Create a :class:`ContextDB` client.
@@ -84,6 +85,8 @@ def init(
         config: Pre-built configuration. When ``None`` one is constructed
             from ``kwargs`` and environment variables prefixed with
             ``CONTEXTDB_``.
+        postgres_pool: Optional externally owned asyncpg pool. Valid only with
+            a PostgreSQL ``storage_url``. ContextDB never closes this pool.
         **kwargs: Forwarded to :class:`ContextDBConfig` if ``config`` is
             not provided.
 
@@ -99,4 +102,5 @@ def init(
         session_id=session_id,
         clock=clock,
         trust_policy=trust_policy,
+        postgres_pool=postgres_pool,
     )

--- a/contextdb/client.py
+++ b/contextdb/client.py
@@ -78,6 +78,7 @@ class ContextDB:
         session_id: str | None = None,
         clock: Clock | None = None,
         trust_policy: TrustPolicy | None = None,
+        postgres_pool: Any | None = None,
     ) -> None:
         self.config = config
         self.user_id = user_id
@@ -89,6 +90,7 @@ class ContextDB:
         self.trust_policy = trust_policy or TrustPolicy(
             relevance_floor=config.relevance_floor
         )
+        self._postgres_pool = postgres_pool
         self._store: BaseStore | None = None
         self._hooks: dict[str, list[Callable[..., Any]]] = {}
         self._embedder: EmbeddingProvider | None = None
@@ -159,6 +161,7 @@ class ContextDB:
             tenant_id=self.tenant_id,
             agent_id=self.agent_id,
             embedding_dim=dim,
+            postgres_pool=self._postgres_pool,
         )
         await self._store.initialize()
         if self._llm is None:

--- a/contextdb/store/factory.py
+++ b/contextdb/store/factory.py
@@ -27,6 +27,7 @@ def open_store(
     tenant_id: str | None = None,
     agent_id: str | None = None,
     embedding_dim: int = 1536,
+    postgres_pool: Any | None = None,
 ) -> BaseStore:
     """Return a SQLite or Postgres store. Postgres needs ``pycontextdb[postgres]``."""
     if is_postgres_url(storage_url):
@@ -43,7 +44,10 @@ def open_store(
             tenant_id=tenant_id,
             agent_id=agent_id,
             embedding_dim=embedding_dim,
+            pool=postgres_pool,
         )
+    if postgres_pool is not None:
+        raise ConfigError("postgres_pool requires a PostgreSQL storage_url")
     return SQLiteStore(
         storage_url=storage_url,
         user_id=user_id,

--- a/contextdb/store/postgres_store.py
+++ b/contextdb/store/postgres_store.py
@@ -150,12 +150,15 @@ class PostgresStore(BaseStore):
         agent_id: str | None = None,
         vector_index: VectorIndex | None = None,
         embedding_dim: int = 1536,
+        pool: Any | None = None,
     ) -> None:
         self._url = storage_url
         self._user_id = user_id
         self._tenant_id = tenant_id
         self._agent_id = agent_id
-        self._pool: Any = None
+        self._pool: Any = pool
+        self._owns_pool = pool is None
+        self._initialized = False
         self._adapter: _PgAdapter | None = None
         self._index: VectorIndex | None = vector_index
         self._embedding_dim = embedding_dim
@@ -172,7 +175,7 @@ class PostgresStore(BaseStore):
         self._audit_guard = asyncio.Lock()
 
     async def initialize(self) -> None:
-        if self._pool is not None:
+        if self._initialized:
             return
         try:
             import asyncpg
@@ -180,7 +183,12 @@ class PostgresStore(BaseStore):
             raise StorageError(
                 "asyncpg is not installed. `pip install 'pycontextdb[postgres]'`."
             ) from exc
-        self._pool = await asyncpg.create_pool(self._url, min_size=1, max_size=10)
+        if self._pool is None:
+            self._pool = await asyncpg.create_pool(
+                self._url,
+                min_size=1,
+                max_size=10,
+            )
         self._adapter = _PgAdapter(self._pool)
         async with self._pool.acquire() as conn:
             for stmt in split_script(_PG_SCHEMA):
@@ -202,6 +210,7 @@ class PostgresStore(BaseStore):
                 await _exec_schema_statement(
                     conn, "ALTER TABLE memories ADD COLUMN IF NOT EXISTS user_id TEXT"
                 )
+        self._initialized = True
 
     def _require_conn(self) -> _PgAdapter:
         if self._adapter is None:
@@ -813,9 +822,11 @@ class PostgresStore(BaseStore):
 
     async def close(self) -> None:
         if self._pool is not None:
-            await self._pool.close()
+            if self._owns_pool:
+                await self._pool.close()
             self._pool = None
             self._adapter = None
+            self._initialized = False
 
 
 def _iso(value: datetime | None) -> str | None:

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -42,6 +42,45 @@ The store is safe to share across processes and workers:
 SQLite remains the single-process backend: its slot and audit locks are
 in-process by design.
 
+## Reusing an application-owned pool
+
+High-throughput hosts should create one asyncpg pool and pass it to scoped
+ContextDB runtimes. ContextDB uses the pool but never closes it.
+
+```python
+import asyncpg
+import contextdb
+
+pool = await asyncpg.create_pool(
+    "postgresql://user:pass@host:5432/contextdb",
+    min_size=2,
+    max_size=20,
+)
+
+support = contextdb.init(
+    storage_url="postgresql://user:pass@host:5432/contextdb",
+    tenant_id="acme",
+    agent_id="support",
+    postgres_pool=pool,
+)
+sales = contextdb.init(
+    storage_url="postgresql://user:pass@host:5432/contextdb",
+    tenant_id="acme",
+    agent_id="sales",
+    postgres_pool=pool,
+)
+
+try:
+    await support.factual.recall("open issue", user_id="customer-42")
+finally:
+    await support.close()
+    await sales.close()
+    await pool.close()
+```
+
+The pool must belong to the same event loop as the runtimes. Passing
+`postgres_pool` with a SQLite URL is a configuration error.
+
 ## Implementing your own store
 
 Subclass `contextdb.store.base.BaseStore`. You need `initialize`, `add`,

--- a/tests/unit/test_pg_sql.py
+++ b/tests/unit/test_pg_sql.py
@@ -1,5 +1,13 @@
-from contextdb.store.factory import is_postgres_url, normalize_postgres_url
+import pytest
+
+from contextdb.core.exceptions import ConfigError
+from contextdb.store.factory import (
+    is_postgres_url,
+    normalize_postgres_url,
+    open_store,
+)
 from contextdb.store.pg_sql import qmark_to_dollar, split_script, translate_sqlite_sql
+from contextdb.store.postgres_store import PostgresStore
 
 
 def test_qmark_to_dollar() -> None:
@@ -32,3 +40,23 @@ def test_postgres_url() -> None:
     assert is_postgres_url("postgres://localhost/db")
     assert not is_postgres_url("sqlite:///x.db")
     assert normalize_postgres_url("postgresql+asyncpg://h/db") == "postgresql://h/db"
+
+
+def test_external_postgres_pool_rejects_sqlite() -> None:
+    with pytest.raises(ConfigError, match="requires a PostgreSQL"):
+        open_store("sqlite:///:memory:", postgres_pool=object())
+
+
+@pytest.mark.asyncio
+async def test_postgres_store_does_not_close_external_pool() -> None:
+    class FakePool:
+        def __init__(self) -> None:
+            self.closed = 0
+
+        async def close(self) -> None:
+            self.closed += 1
+
+    pool = FakePool()
+    store = PostgresStore("postgresql://example/contextdb", pool=pool)
+    await store.close()
+    assert pool.closed == 0

--- a/tests/unit/test_postgres_concurrency.py
+++ b/tests/unit/test_postgres_concurrency.py
@@ -55,6 +55,47 @@ async def _close_all(clients: list[ContextDB]) -> None:
 
 
 @pytest.mark.asyncio
+async def test_external_pool_is_shared_and_not_closed_by_clients() -> None:
+    import asyncpg
+
+    async with fresh_pg_database() as url:
+        pool = await asyncpg.create_pool(url, min_size=1, max_size=4)
+        first = contextdb.init(
+            config=_cfg(url),
+            tenant_id="tenant-shared",
+            agent_id="agent-shared",
+            postgres_pool=pool,
+        )
+        second = contextdb.init(
+            config=_cfg(url),
+            tenant_id="tenant-shared",
+            agent_id="agent-shared",
+            postgres_pool=pool,
+        )
+        try:
+            stored = await first.factual.add(
+                "The shared pool remains open",
+                source="user_stated",
+                user_id="user-shared",
+            )
+            await first.close()
+            async with pool.acquire() as conn:
+                assert await conn.fetchval("SELECT 1") == 1
+            memories = await second.factual.list_facts(
+                user_id="user-shared",
+                limit=10,
+            )
+            assert stored.id in {memory.id for memory in memories}
+            await second.close()
+            async with pool.acquire() as conn:
+                assert await conn.fetchval("SELECT 1") == 1
+        finally:
+            await first.close()
+            await second.close()
+            await pool.close()
+
+
+@pytest.mark.asyncio
 async def test_concurrent_slot_writes_do_not_lose_corroboration() -> None:
     """Six workers restating the same slot value in different sessions must
     all land as independent corroboration — the cross-process slot lock


### PR DESCRIPTION
## Summary
- add an explicit postgres_pool argument to contextdb.init and ContextDB
- let PostgresStore use an externally owned asyncpg pool without closing it
- reject pool injection for SQLite URLs
- document safe shared-pool ownership for multi-project hosts
- add a real Postgres CI job so concurrency and shared-pool tests stop silently skipping

## Why
ContextDB Cloud measured roughly 99 ms of setup cost from creating and closing one asyncpg pool per request. Reused runtimes reduced direct recall to 13.53 ms p95, but one pool per cached project would multiply database connections. Explicit pool injection lets scoped stores share physical connections without weakening tenant/project query scope.

## Test plan
- [x] 119 SDK unit tests passed; 14 Postgres-dependent tests skipped locally
- [x] 34 trust-model evals passed
- [x] Ruff passed
- [x] Mypy passed for Python 3.12 target
- [x] Add real Postgres test proving two scoped clients share a pool and client close does not close host ownership
- [x] Add CI Postgres service job for concurrency, scope, and vector visibility tests

Made with [Cursor](https://cursor.com)