### PR TITLE
Bind advisory work to its locked connection

### DIFF
--- a/contextdb/store/postgres_store.py
+++ b/contextdb/store/postgres_store.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterator, Callable, Mapping
+from contextvars import ContextVar
 from datetime import datetime, timezone
 from typing import Any
 
@@ -69,21 +70,47 @@ class _PgAdapter:
 
     def __init__(self, pool: Any) -> None:
         self._pool = pool
+        self._bound_connection: ContextVar[Any | None] = ContextVar(
+            f"contextdb_pg_connection_{id(self)}",
+            default=None,
+        )
+
+    def bind(self, connection: Any) -> Any:
+        return self._bound_connection.set(connection)
+
+    def reset(self, token: Any) -> None:
+        self._bound_connection.reset(token)
+
+    async def _execute(
+        self,
+        conn: Any,
+        translated: str,
+        params: tuple[Any, ...] | list[Any],
+    ) -> _PgResult:
+        stripped = translated.lstrip().upper()
+        if stripped.startswith("SELECT") or "RETURNING" in stripped:
+            rows = await conn.fetch(translated, *params)
+            return _PgResult([dict(row) for row in rows], rowcount=len(rows))
+        status = await conn.execute(translated, *params)
+        count = 0
+        if isinstance(status, str) and status.split()[-1].isdigit():
+            count = int(status.split()[-1])
+        return _PgResult([], rowcount=count)
 
     async def execute(self, sql: str, params: tuple[Any, ...] | list[Any] = ()) -> _PgResult:
         translated = translate_sqlite_sql(sql)
+        bound = self._bound_connection.get()
+        if bound is not None:
+            return await self._execute(bound, translated, params)
         async with self._pool.acquire() as conn:
-            stripped = translated.lstrip().upper()
-            if stripped.startswith("SELECT") or "RETURNING" in stripped:
-                rows = await conn.fetch(translated, *params)
-                return _PgResult([dict(row) for row in rows], rowcount=len(rows))
-            status = await conn.execute(translated, *params)
-            count = 0
-            if isinstance(status, str) and status.split()[-1].isdigit():
-                count = int(status.split()[-1])
-            return _PgResult([], rowcount=count)
+            return await self._execute(conn, translated, params)
 
     async def executescript(self, script: str) -> None:
+        bound = self._bound_connection.get()
+        if bound is not None:
+            for stmt in split_script(script):
+                await _exec_schema_statement(bound, translate_sqlite_sql(stmt))
+            return
         async with self._pool.acquire() as conn:
             for stmt in split_script(script):
                 await _exec_schema_statement(conn, translate_sqlite_sql(stmt))
@@ -97,18 +124,20 @@ class _PgAdvisoryLock:
 
     ``pg_advisory_xact_lock`` serializes holders of the same key across
     every connection and process on the database; the transaction ends
-    the hold. The in-process ``guard`` runs first so one event loop can
-    hold at most one pool connection while *waiting* on the advisory
-    lock — without it, N waiting tasks would hold N connections and a
-    lock holder's own critical section could starve the pool.
+    the hold. The adapter binds the critical section to the same connection,
+    making read-modify-write atomic and ensuring a lock holder never needs a
+    second pool connection while other scoped stores wait on the same lock.
+    The in-process ``guard`` additionally limits waiters per store.
     """
 
-    def __init__(self, pool: Any, key: str, guard: asyncio.Lock) -> None:
-        self._pool = pool
+    def __init__(self, adapter: _PgAdapter, key: str, guard: asyncio.Lock) -> None:
+        self._adapter = adapter
+        self._pool = adapter._pool
         self._key = key
         self._guard = guard
         self._conn: Any = None
         self._tx: Any = None
+        self._binding: Any = None
 
     async def __aenter__(self) -> _PgAdvisoryLock:
         await self._guard.acquire()
@@ -119,11 +148,18 @@ class _PgAdvisoryLock:
             await self._conn.execute(
                 "SELECT pg_advisory_xact_lock(hashtext($1))", self._key
             )
+            self._binding = self._adapter.bind(self._conn)
         except BaseException:
-            if self._conn is not None:
-                await self._pool.release(self._conn)
-                self._conn = None
-            self._guard.release()
+            try:
+                if self._tx is not None:
+                    await self._tx.rollback()
+            finally:
+                try:
+                    if self._conn is not None:
+                        await self._pool.release(self._conn)
+                        self._conn = None
+                finally:
+                    self._guard.release()
             raise
         return self
 
@@ -134,9 +170,14 @@ class _PgAdvisoryLock:
             else:
                 await self._tx.rollback()
         finally:
-            await self._pool.release(self._conn)
-            self._conn = None
-            self._guard.release()
+            if self._binding is not None:
+                self._adapter.reset(self._binding)
+                self._binding = None
+            try:
+                await self._pool.release(self._conn)
+                self._conn = None
+            finally:
+                self._guard.release()
 
 
 class PostgresStore(BaseStore):
@@ -217,11 +258,6 @@ class PostgresStore(BaseStore):
             raise StorageError("PostgresStore is not initialized. Call initialize() first.")
         return self._adapter
 
-    def _require_pool(self) -> Any:
-        if self._pool is None:
-            raise StorageError("PostgresStore is not initialized. Call initialize() first.")
-        return self._pool
-
     def _resolve_scope(self, user_id: str | None) -> str | None:
         if self._user_id is not None:
             return self._user_id
@@ -264,13 +300,17 @@ class PostgresStore(BaseStore):
         scope = self._resolve_scope(user_id)
         key = "|".join((scope or "", self._tenant_id or "", entity_key, attribute_key))
         return _PgAdvisoryLock(
-            self._require_pool(), f"contextdb-slot:{key}", self._slot_advisory_gate
+            self._require_conn(),
+            f"contextdb-slot:{key}",
+            self._slot_advisory_gate,
         )
 
     def audit_lock(self) -> _PgAdvisoryLock:
         """Cross-process serialization for hash-chain appends."""
         return _PgAdvisoryLock(
-            self._require_pool(), "contextdb-audit-chain", self._audit_guard
+            self._require_conn(),
+            "contextdb-audit-chain",
+            self._audit_guard,
         )
 
     async def _fetch(

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -81,6 +81,10 @@ finally:
 The pool must belong to the same event loop as the runtimes. Passing
 `postgres_pool` with a SQLite URL is a configuration error.
 
+Slot and audit advisory-lock critical sections stay on the connection that
+acquired the transaction lock. This keeps read-modify-write atomic and prevents
+scoped stores waiting on a saturated shared pool from starving the lock holder.
+
 ## Implementing your own store
 
 Subclass `contextdb.store.base.BaseStore`. You need `initialize`, `add`,

--- a/tests/unit/test_pg_sql.py
+++ b/tests/unit/test_pg_sql.py
@@ -7,7 +7,7 @@ from contextdb.store.factory import (
     open_store,
 )
 from contextdb.store.pg_sql import qmark_to_dollar, split_script, translate_sqlite_sql
-from contextdb.store.postgres_store import PostgresStore
+from contextdb.store.postgres_store import PostgresStore, _PgAdapter
 
 
 def test_qmark_to_dollar() -> None:
@@ -60,3 +60,35 @@ async def test_postgres_store_does_not_close_external_pool() -> None:
     store = PostgresStore("postgresql://example/contextdb", pool=pool)
     await store.close()
     assert pool.closed == 0
+
+
+@pytest.mark.asyncio
+async def test_bound_adapter_reuses_advisory_transaction_connection() -> None:
+    class NoAcquirePool:
+        def acquire(self) -> None:
+            raise AssertionError("bound execution must not acquire another connection")
+
+    class FakeConnection:
+        def __init__(self) -> None:
+            self.statements: list[str] = []
+
+        async def fetch(self, sql: str, *params: object) -> list[dict[str, int]]:
+            self.statements.append(sql)
+            return [{"value": 1}]
+
+        async def execute(self, sql: str, *params: object) -> str:
+            self.statements.append(sql)
+            return "UPDATE 1"
+
+    adapter = _PgAdapter(NoAcquirePool())
+    connection = FakeConnection()
+    token = adapter.bind(connection)
+    try:
+        selected = await adapter.execute("SELECT value FROM example")
+        updated = await adapter.execute("UPDATE example SET value = ?", (2,))
+    finally:
+        adapter.reset(token)
+
+    assert await selected.fetchall() == [{"value": 1}]
+    assert updated.rowcount == 1
+    assert len(connection.statements) == 2

--- a/tests/unit/test_postgres_concurrency.py
+++ b/tests/unit/test_postgres_concurrency.py
@@ -22,6 +22,7 @@ import pytest
 import contextdb
 from contextdb import ContextDB
 from contextdb.core.config import ContextDBConfig
+from contextdb.store.postgres_store import PostgresStore
 from tests.pg_util import fresh_pg_database
 
 pytestmark = pytest.mark.skipif(
@@ -92,6 +93,53 @@ async def test_external_pool_is_shared_and_not_closed_by_clients() -> None:
         finally:
             await first.close()
             await second.close()
+            await pool.close()
+
+
+@pytest.mark.asyncio
+async def test_shared_pool_audit_waiters_cannot_starve_lock_holder() -> None:
+    import asyncpg
+
+    async with fresh_pg_database() as url:
+        pool = await asyncpg.create_pool(url, min_size=4, max_size=4)
+        stores = [PostgresStore(url, pool=pool) for _ in range(4)]
+        for store in stores:
+            await store.initialize()
+
+        holder_entered = asyncio.Event()
+        release_holder = asyncio.Event()
+
+        async def holder() -> None:
+            async with stores[0].audit_lock():
+                holder_entered.set()
+                await release_holder.wait()
+                await stores[0]._require_conn().execute("SELECT 1")
+
+        async def waiter(store: PostgresStore) -> None:
+            async with store.audit_lock():
+                await store._require_conn().execute("SELECT 1")
+
+        tasks = [asyncio.create_task(holder())]
+        try:
+            await holder_entered.wait()
+            tasks.extend(
+                asyncio.create_task(waiter(store))
+                for store in stores[1:]
+            )
+            for _ in range(100):
+                if pool.get_idle_size() == 0:
+                    break
+                await asyncio.sleep(0.01)
+            assert pool.get_idle_size() == 0
+            release_holder.set()
+            await asyncio.wait_for(asyncio.gather(*tasks), timeout=5)
+        finally:
+            release_holder.set()
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            for store in stores:
+                await store.close()
             await pool.close()
 
 


### PR DESCRIPTION
## Summary
- bind Postgres adapter calls to the connection holding a transaction-scoped advisory lock
- make slot and audit read-modify-write critical sections one database transaction
- prevent many scoped stores sharing a saturated pool from starving the advisory lock holder
- add a deterministic real-Postgres saturation regression test

## Why
With externally pooled project stores, each store has its own in-process audit gate. Enough different projects can occupy every pool connection while waiting for the global audit advisory lock. Previously the lock holder then tried to acquire a second connection for the audit body and could deadlock. Reusing the locked connection removes that circular wait and makes the critical section atomic.

## Verification
- 154 SDK unit/eval tests passed; 15 Postgres-dependent tests skipped locally
- Ruff and Python 3.12 mypy passed
- isolated production-Postgres proof saturated a four-connection pool with one holder plus three waiters, completed all waiters, appended 20 concurrent audit records, and verified the chain

Made with [Cursor](https://cursor.com)