### PR TITLE
Allow durable read auditing outside recall

### DIFF
--- a/contextdb/client.py
+++ b/contextdb/client.py
@@ -319,8 +319,12 @@ class ContextDB:
         event: str,
         hook: Callable[[str, dict[str, Any]], Awaitable[None] | None],
     ) -> None:
-        """Register an ops callback. Events: write, recall, confirm, forget,
-        injection_suspect, embed_fallback. Use ``*`` for all events.
+        """Register an ops callback. Events: write, recall, read_audit,
+        confirm, forget, injection_suspect, embed_fallback. Use ``*`` for all.
+
+        ``read_audit`` receives only the PII-processed audit payload. Hosted
+        runtimes that disable synchronous read auditing should durably persist
+        this event before returning a successful recall.
         """
         self._hooks.setdefault(event, []).append(hook)
 
@@ -662,11 +666,15 @@ class ContextDB:
                 details=audit_details,
             )
         await self._emit(
+            "read_audit",
+            user_id=uid,
+            audit_details=audit_details,
+        )
+        await self._emit(
             "recall",
             user_id=uid,
             query=query,
             hits=len(items),
-            audit_details=audit_details,
         )
         return items
 

--- a/contextdb/client.py
+++ b/contextdb/client.py
@@ -617,48 +617,57 @@ class ContextDB:
         items = items[:top_k]
         if compose:
             items = await self._compose_siblings(items, moment, extra=top_k, user_id=uid)
-        if self._audit is not None:
-            score_by_id = {s.item.id: s for s in scored}
+        score_by_id = {s.item.id: s for s in scored}
+        returned_ids = [memory.id for memory in items]
+        returned_id_set = set(returned_ids)
+        audit_details = {
+            # The audit chain is append-only; only the redacted
+            # form of the query may be persisted.
+            "query": processed_query,
+            "hits": len(items),
+            "returned_ids": returned_ids,
+            "as_of": moment.isoformat(),
+            "relevance_floor": floor,
+            "abstained": len(items) == 0,
+            # Recall-side observability (Epic 6): every recall logs
+            # the full score decomposition AND the decision flags
+            # as they stood at recall time — computed properties
+            # change after confirm(), so a diary of scores without
+            # the decision is not an audit.
+            "scores": {
+                mid: {
+                    "final": round(s.final_score, 6),
+                    "rrf": round(s.rrf_score, 6),
+                    "salience": round(s.salience, 6),
+                    "age_days": round(s.age_days, 3),
+                    "recurrence": s.recurrence,
+                    "criticality_boost": s.criticality_boost,
+                    "per_graph": s.per_graph,
+                    "requires_confirmation": self.trust_policy.requires_confirmation(
+                        s.item
+                    ),
+                    "action_trusted": self.trust_policy.is_trusted(s.item),
+                    "confirmed": s.item.confirmed,
+                    "contested": s.item.contested,
+                    "independent_corroboration": s.item.independent_corroboration,
+                }
+                for mid, s in score_by_id.items()
+                if mid in returned_id_set
+            },
+        }
+        if self._audit is not None and self.config.enable_read_audit:
             await self._audit.log(
                 operation="SEARCH",
                 user_id=uid,
-                details={
-                    # The audit chain is append-only; only the redacted
-                    # form of the query may be persisted.
-                    "query": processed_query,
-                    "hits": len(items),
-                    "returned_ids": [m.id for m in items],
-                    "as_of": moment.isoformat(),
-                    "relevance_floor": floor,
-                    "abstained": len(items) == 0,
-                    # Recall-side observability (Epic 6): every recall logs
-                    # the full score decomposition AND the decision flags
-                    # as they stood at recall time — computed properties
-                    # change after confirm(), so a diary of scores without
-                    # the decision is not an audit.
-                    "scores": {
-                        mid: {
-                            "final": round(s.final_score, 6),
-                            "rrf": round(s.rrf_score, 6),
-                            "salience": round(s.salience, 6),
-                            "age_days": round(s.age_days, 3),
-                            "recurrence": s.recurrence,
-                            "criticality_boost": s.criticality_boost,
-                            "per_graph": s.per_graph,
-                            "requires_confirmation": self.trust_policy.requires_confirmation(
-                                s.item
-                            ),
-                            "action_trusted": self.trust_policy.is_trusted(s.item),
-                            "confirmed": s.item.confirmed,
-                            "contested": s.item.contested,
-                            "independent_corroboration": s.item.independent_corroboration,
-                        }
-                        for mid, s in score_by_id.items()
-                        if mid in {m.id for m in items}
-                    },
-                },
+                details=audit_details,
             )
-        await self._emit("recall", user_id=uid, query=query, hits=len(items))
+        await self._emit(
+            "recall",
+            user_id=uid,
+            query=query,
+            hits=len(items),
+            audit_details=audit_details,
+        )
         return items
 
     async def _lexical_scored(

--- a/contextdb/core/config.py
+++ b/contextdb/core/config.py
@@ -115,6 +115,15 @@ class ContextDBConfig(BaseSettings):
     enable_multi_graph: bool = Field(default=False)
     enable_rl_manager: bool = Field(default=False)
     enable_audit: bool = Field(default=True)
+    enable_read_audit: bool = Field(
+        default=True,
+        description=(
+            "Append SEARCH events to the synchronous SDK audit chain. "
+            "High-throughput hosts may disable this only when they durably "
+            "consume the recall hook's redacted audit_details payload. "
+            "Write and lifecycle audit events remain enabled."
+        ),
+    )
     enable_auto_link: bool = Field(default=True)
     require_source: bool = Field(
         default=False,

--- a/contextdb/core/config.py
+++ b/contextdb/core/config.py
@@ -120,7 +120,7 @@ class ContextDBConfig(BaseSettings):
         description=(
             "Append SEARCH events to the synchronous SDK audit chain. "
             "High-throughput hosts may disable this only when they durably "
-            "consume the recall hook's redacted audit_details payload. "
+            "consume the read_audit hook's redacted audit_details payload. "
             "Write and lifecycle audit events remain enabled."
         ),
     )

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -57,7 +57,13 @@ here works offline.
 | `enable_multi_graph`  | `False` | Temporal + causal graphs |
 | `enable_rl_manager`   | `False` | Inference-time memory policy |
 | `enable_audit`        | `True`  | Hash-chained audit log |
+| `enable_read_audit`   | `True`  | Synchronous `SEARCH` entries in that chain |
 | `enable_auto_link`    | `True`  | Mirror each write into graph indices |
+
+`enable_read_audit=False` does not disable write, confirmation, or lifecycle
+audit events. It is for high-throughput hosts that register a `recall` hook and
+durably persist its PII-processed `audit_details` payload elsewhere. Dropping
+that payload silently is not equivalent to auditing reads.
 
 Pass `trust_policy=TrustPolicy.hospital()` (or `.restaurant()`) to change
 the action bar without forking the product. Pass `clock=FrozenClock(...)`

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -61,9 +61,9 @@ here works offline.
 | `enable_auto_link`    | `True`  | Mirror each write into graph indices |
 
 `enable_read_audit=False` does not disable write, confirmation, or lifecycle
-audit events. It is for high-throughput hosts that register a `recall` hook and
-durably persist its PII-processed `audit_details` payload elsewhere. Dropping
-that payload silently is not equivalent to auditing reads.
+audit events. It is for high-throughput hosts that register a `read_audit` hook
+and durably persist its PII-processed `audit_details` payload elsewhere.
+Dropping that payload silently is not equivalent to auditing reads.
 
 Pass `trust_policy=TrustPolicy.hospital()` (or `.restaurant()`) to change
 the action bar without forking the product. Pass `clock=FrozenClock(...)`

--- a/tests/unit/test_decision_scope.py
+++ b/tests/unit/test_decision_scope.py
@@ -147,7 +147,7 @@ async def test_deferred_read_audit_emits_redacted_details_and_keeps_write_audit(
     async def capture(_event: str, payload: dict[str, object]) -> None:
         recalls.append(payload)
 
-    db.on("recall", capture)
+    db.on("read_audit", capture)
     try:
         stored = await db.factual.add(
             "My email is jane.doe@example.com",
@@ -167,6 +167,31 @@ async def test_deferred_read_audit_emits_redacted_details_and_keeps_write_audit(
         assert "jane.doe@example.com" not in str(details)
         assert stored.id in details["returned_ids"]
         assert stored.id in details["scores"]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_deferred_read_audit_sink_failure_fails_recall(
+    tmp_path: Path,
+) -> None:
+    db = contextdb.init(
+        user_id="alice",
+        config=_cfg(tmp_path, enable_read_audit=False),
+    )
+
+    async def unavailable(_event: str, _payload: dict[str, object]) -> None:
+        raise RuntimeError("durable read audit unavailable")
+
+    db.on("read_audit", unavailable)
+    try:
+        with pytest.raises(RuntimeError, match="durable read audit unavailable"):
+            await db.search("anything")
+        assert db.audit is not None
+        assert all(
+            entry.operation != "SEARCH"
+            for entry in await db.audit.get_history()
+        )
     finally:
         await db.close()
 

--- a/tests/unit/test_decision_scope.py
+++ b/tests/unit/test_decision_scope.py
@@ -135,6 +135,43 @@ async def test_search_audit_log_never_stores_raw_pii_query(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
+async def test_deferred_read_audit_emits_redacted_details_and_keeps_write_audit(
+    tmp_path: Path,
+) -> None:
+    db = contextdb.init(
+        user_id="alice",
+        config=_cfg(tmp_path, enable_read_audit=False),
+    )
+    recalls: list[dict[str, object]] = []
+
+    async def capture(_event: str, payload: dict[str, object]) -> None:
+        recalls.append(payload)
+
+    db.on("recall", capture)
+    try:
+        stored = await db.factual.add(
+            "My email is jane.doe@example.com",
+            source="user_stated",
+        )
+        await db.search("please look up jane.doe@example.com")
+        assert db.audit is not None
+        entries = await db.audit.get_history()
+        assert any(entry.operation == "CREATE" for entry in entries)
+        assert all(entry.operation != "SEARCH" for entry in entries)
+        assert await db.audit.verify_chain()
+
+        assert len(recalls) == 1
+        details = recalls[0]["audit_details"]
+        assert isinstance(details, dict)
+        assert details["query"] == "please look up [EMAIL]"
+        assert "jane.doe@example.com" not in str(details)
+        assert stored.id in details["returned_ids"]
+        assert stored.id in details["scores"]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
 async def test_encrypt_pii_action_fails_closed_without_key(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- preserve synchronous SEARCH audit as the default
- add enable_read_audit for hosts with a durable external read-audit sink
- emit a dedicated read_audit hook containing only the PII-processed evidence payload
- keep raw-query operational recall hooks separate
- fail recall if a registered durable sink fails
- leave write, confirmation, decision, and lifecycle auditing unchanged

## Why
Hosted recall is otherwise forced through one database-global audit-chain append. This contract lets Cloud durably enqueue the identical redacted evidence before returning, then hash-chain it per organization outside retrieval.

## Verification
- 156 SDK unit/eval tests passed under CI timing budgets; 15 real-Postgres tests skipped locally
- Ruff passed
- Python 3.12 mypy passed
- regression coverage proves defaults remain synchronous, write audit remains intact when read audit is deferred, raw PII never reaches the durable hook, and sink failure fails recall

Made with [Cursor](https://cursor.com)