### PR TITLE
Version embeddings by model and retrieval role

### DIFF
--- a/contextdb/client.py
+++ b/contextdb/client.py
@@ -162,6 +162,7 @@ class ContextDB:
             tenant_id=self.tenant_id,
             agent_id=self.agent_id,
             embedding_dim=dim,
+            embedding_model_id=self.config.embedding_model,
             postgres_pool=self._postgres_pool,
         )
         await self._store.initialize()
@@ -491,7 +492,9 @@ class ContextDB:
             if action == "DELETE" and decision.get("target_memory_id"):
                 await self.delete(decision["target_memory_id"])
 
-        embedding = (await self._embedder.embed([embed_text]))[0]
+        embedding = (
+            await self._embedder.embed_documents([embed_text])
+        )[0]
         now = self.clock()
         item = MemoryItem(
             content=processed,
@@ -597,7 +600,9 @@ class ContextDB:
         processed_query, _query_pii = self._pii.process(query)
         scored: list[Any]
         try:
-            query_embedding = (await self._embedder.embed([processed_query]))[0]
+            query_embedding = await self._embedder.embed_query(
+                processed_query
+            )
             scored = await self._retrieval.search_scored(
                 query, query_embedding, top_k=top_k * 3, user_id=uid
             )
@@ -744,7 +749,9 @@ class ContextDB:
         processed, pii_annotations = self._pii.process(content)
         shadow = self._pii_shadow(pii_annotations, processed)
         embed_text = shadow or processed
-        embedding = (await self._embedder.embed([embed_text]))[0]
+        embedding = (
+            await self._embedder.embed_documents([embed_text])
+        )[0]
         now = self.clock()
         item = MemoryItem(
             content=processed,
@@ -841,7 +848,11 @@ class ContextDB:
                 continue
             for fact in facts:
                 fact_content, fact_pii = self._pii.process(fact["content"])
-                embedding = (await self._embedder.embed([fact_content]))[0]
+                embedding = (
+                    await self._embedder.embed_documents(
+                        [fact_content]
+                    )
+                )[0]
                 new_item = MemoryItem(
                     content=fact_content,
                     embedding=embedding,
@@ -941,7 +952,9 @@ class ContextDB:
         kwargs: dict[str, Any] = {}
         if content is not None:
             processed, pii = self._pii.process(content)
-            embedding = (await self._embedder.embed([processed]))[0]
+            embedding = (
+                await self._embedder.embed_documents([processed])
+            )[0]
             kwargs["content"] = processed
             kwargs["embedding"] = embedding
             kwargs["pii_annotations"] = pii

--- a/contextdb/core/models.py
+++ b/contextdb/core/models.py
@@ -178,6 +178,7 @@ class MemoryItem(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid4()))
     content: str
     embedding: list[float] | None = None
+    embedding_model_id: str | None = None
     memory_type: MemoryType = MemoryType.FACTUAL
     source: str = ""
     metadata: dict[str, Any] = Field(default_factory=dict)

--- a/contextdb/store/factory.py
+++ b/contextdb/store/factory.py
@@ -27,6 +27,7 @@ def open_store(
     tenant_id: str | None = None,
     agent_id: str | None = None,
     embedding_dim: int = 1536,
+    embedding_model_id: str | None = None,
     postgres_pool: Any | None = None,
 ) -> BaseStore:
     """Return a SQLite or Postgres store. Postgres needs ``pycontextdb[postgres]``."""
@@ -44,6 +45,7 @@ def open_store(
             tenant_id=tenant_id,
             agent_id=agent_id,
             embedding_dim=embedding_dim,
+            embedding_model_id=embedding_model_id,
             pool=postgres_pool,
         )
     if postgres_pool is not None:
@@ -54,6 +56,7 @@ def open_store(
         tenant_id=tenant_id,
         agent_id=agent_id,
         embedding_dim=embedding_dim,
+        embedding_model_id=embedding_model_id,
     )
 
 

--- a/contextdb/store/postgres_store.py
+++ b/contextdb/store/postgres_store.py
@@ -266,6 +266,7 @@ class PostgresStore(BaseStore):
         vector_index: VectorIndex | None = None,
         embedding_dim: int = 1536,
         pool: Any | None = None,
+        embedding_model_id: str | None = None,
     ) -> None:
         self._url = storage_url
         self._user_id = user_id
@@ -279,6 +280,7 @@ class PostgresStore(BaseStore):
         self._index: VectorIndex | None = vector_index
         self._index_items: dict[str, MemoryItem] = {}
         self._embedding_dim = embedding_dim
+        self._embedding_model_id = embedding_model_id
         self._index_loaded = False
         self._loaded_revision: int | None = None
         self._write_lock = asyncio.Lock()
@@ -326,6 +328,14 @@ class PostgresStore(BaseStore):
             if "user_id" not in cols:
                 await _exec_schema_statement(
                     conn, "ALTER TABLE memories ADD COLUMN IF NOT EXISTS user_id TEXT"
+                )
+            if self._embedding_model_id is not None:
+                await conn.execute(
+                    "UPDATE memories SET embedding_model_id = $1 "
+                    "WHERE embedding_model_id IS NULL "
+                    "AND embedding_dim = $2",
+                    self._embedding_model_id,
+                    self._embedding_dim,
                 )
         self._initialized = True
 
@@ -574,6 +584,9 @@ class PostgresStore(BaseStore):
             "AND embedding_dim = ?"
         )
         params: list[Any] = [self._embedding_dim]
+        if self._embedding_model_id is not None:
+            sql += " AND embedding_model_id = ?"
+            params.append(self._embedding_model_id)
         if scope_sql:
             sql += f" AND {scope_sql}"
             params.extend(scope_params)
@@ -640,6 +653,13 @@ class PostgresStore(BaseStore):
         if self._user_id is not None and uid is not None and uid != self._user_id:
             raise StorageError("cannot write another user's memory into a scoped store")
         item.user_id = uid
+        if item.embedding is not None and self._embedding_model_id is not None:
+            if (
+                item.embedding_model_id is not None
+                and item.embedding_model_id != self._embedding_model_id
+            ):
+                raise StorageError("memory embedding model does not match store")
+            item.embedding_model_id = self._embedding_model_id
         blob, dim = _embedding_to_blob(item.embedding)
         async with self._write_lock:
             await self._execute(
@@ -654,11 +674,11 @@ class PostgresStore(BaseStore):
                     superseded_by, pending_consolidation, injection_suspect,
                     corroborated_by, confirmed, confirmed_at, write_generation,
                     slot_class, slot_value, negated, tenant_id, agent_id,
-                    session_id, pii_shadow, contested
+                    session_id, pii_shadow, contested, embedding_model_id
                 ) VALUES (
                     ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,
                     ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,
-                    ?,?
+                    ?,?,?
                 )
                 """,
                 (
@@ -704,6 +724,7 @@ class PostgresStore(BaseStore):
                     item.session_id,
                     item.pii_shadow,
                     int(item.contested),
+                    item.embedding_model_id,
                 ),
             )
             revision = await self._bump_revision()
@@ -754,11 +775,14 @@ class PostgresStore(BaseStore):
         current = await self.get_raw(memory_id)
         if current is None:
             raise MemoryNotFoundError(memory_id)
+        if "embedding" in kwargs and self._embedding_model_id is not None:
+            kwargs["embedding_model_id"] = self._embedding_model_id
         sets: list[str] = []
         params: list[Any] = []
         allowed = {
             "content",
             "embedding",
+            "embedding_model_id",
             "metadata",
             "status",
             "source",

--- a/contextdb/store/sqlite_store.py
+++ b/contextdb/store/sqlite_store.py
@@ -36,6 +36,7 @@ CREATE TABLE IF NOT EXISTS memories (
     content TEXT NOT NULL,
     embedding BLOB,
     embedding_dim INTEGER,
+    embedding_model_id TEXT,
     memory_type TEXT NOT NULL DEFAULT 'FACTUAL',
     source TEXT DEFAULT '',
     metadata TEXT DEFAULT '{}',
@@ -170,6 +171,7 @@ _TRUST_COLUMNS: list[tuple[str, str]] = [
     ("session_id", "TEXT"),
     ("pii_shadow", "TEXT"),
     ("contested", "INTEGER NOT NULL DEFAULT 0"),
+    ("embedding_model_id", "TEXT"),
 ]
 
 
@@ -227,6 +229,7 @@ def _row_to_item(row: Mapping[str, Any]) -> MemoryItem:
         id=row["id"],
         content=row["content"],
         embedding=_blob_to_embedding(row["embedding"]),
+        embedding_model_id=row["embedding_model_id"],
         memory_type=MemoryType(row["memory_type"]),
         source=row["source"] or "",
         metadata=json.loads(row["metadata"] or "{}"),
@@ -288,6 +291,7 @@ class SQLiteStore(BaseStore):
         agent_id: str | None = None,
         vector_index: VectorIndex | None = None,
         embedding_dim: int = 1536,
+        embedding_model_id: str | None = None,
     ) -> None:
         self._path = _parse_storage_url(storage_url)
         self._user_id = user_id
@@ -297,6 +301,7 @@ class SQLiteStore(BaseStore):
         self._conn: aiosqlite.Connection | None = None
         self._index: VectorIndex | None = vector_index
         self._embedding_dim = embedding_dim
+        self._embedding_model_id = embedding_model_id
         self._index_loaded = False
         self._loaded_revision: int | None = None
         self._write_lock: asyncio.Lock = asyncio.Lock()
@@ -320,6 +325,15 @@ class SQLiteStore(BaseStore):
         await self._conn.execute("PRAGMA busy_timeout=5000")
         await self._conn.executescript(SCHEMA)
         await self._migrate(self._conn)
+        if self._embedding_model_id is not None:
+            await self._conn.execute(
+                "UPDATE memories SET embedding_model_id = ? "
+                "WHERE embedding_model_id IS NULL AND embedding_dim = ?",
+                (
+                    self._embedding_model_id,
+                    self._embedding_dim,
+                ),
+            )
         await self._conn.commit()
 
     @staticmethod
@@ -474,11 +488,18 @@ class SQLiteStore(BaseStore):
         assert self._index is not None
         conn = self._require_conn()
         self._index.remove(self._index.ids())
-        cursor = await conn.execute(
+        sql = (
             "SELECT id, embedding, embedding_dim FROM memories "
             "WHERE embedding IS NOT NULL AND status = 'ACTIVE' "
-            "AND embedding_dim = ?",
-            (self._embedding_dim,),
+            "AND embedding_dim = ?"
+        )
+        params: list[Any] = [self._embedding_dim]
+        if self._embedding_model_id is not None:
+            sql += " AND embedding_model_id = ?"
+            params.append(self._embedding_model_id)
+        cursor = await conn.execute(
+            sql,
+            params,
         )
         rows = await cursor.fetchall()
         if rows:
@@ -523,6 +544,13 @@ class SQLiteStore(BaseStore):
         if self._user_id is not None and uid is not None and uid != self._user_id:
             raise StorageError("cannot write another user's memory into a scoped store")
         item.user_id = uid
+        if item.embedding is not None and self._embedding_model_id is not None:
+            if (
+                item.embedding_model_id is not None
+                and item.embedding_model_id != self._embedding_model_id
+            ):
+                raise StorageError("memory embedding model does not match store")
+            item.embedding_model_id = self._embedding_model_id
         blob, dim = _embedding_to_blob(item.embedding)
         async with self._write_lock:
             await conn.execute(
@@ -537,11 +565,11 @@ class SQLiteStore(BaseStore):
                     superseded_by, pending_consolidation, injection_suspect,
                     corroborated_by, confirmed, confirmed_at, write_generation,
                     slot_class, slot_value, negated, tenant_id, agent_id,
-                    session_id, pii_shadow, contested
+                    session_id, pii_shadow, contested, embedding_model_id
                 ) VALUES (
                     ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,
                     ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,
-                    ?,?
+                    ?,?,?
                 )
                 """,
                 (
@@ -587,6 +615,7 @@ class SQLiteStore(BaseStore):
                     item.session_id,
                     item.pii_shadow,
                     int(item.contested),
+                    item.embedding_model_id,
                 ),
             )
             revision = await self._bump_revision(conn)
@@ -621,10 +650,13 @@ class SQLiteStore(BaseStore):
         current = await self.get_raw(memory_id)
         if current is None:
             raise MemoryNotFoundError(memory_id)
+        if "embedding" in kwargs and self._embedding_model_id is not None:
+            kwargs["embedding_model_id"] = self._embedding_model_id
 
         allowed = {
             "content",
             "embedding",
+            "embedding_model_id",
             "metadata",
             "status",
             "source",

--- a/contextdb/utils/embeddings.py
+++ b/contextdb/utils/embeddings.py
@@ -35,6 +35,17 @@ class EmbeddingProvider(ABC):
     @abstractmethod
     def dimension(self) -> int: ...
 
+    async def embed_query(self, text: str) -> list[float]:
+        """Embed one retrieval query."""
+        return (await self.embed([text]))[0]
+
+    async def embed_documents(
+        self,
+        texts: list[str],
+    ) -> list[list[float]]:
+        """Embed stored memory/document text."""
+        return await self.embed(texts)
+
 
 class OpenAIEmbedding(EmbeddingProvider):
     """OpenAI embedding API wrapper with exponential-backoff retry.
@@ -105,6 +116,7 @@ class SentenceTransformerEmbedding(EmbeddingProvider):
                 "Install with `pip install pycontextdb[local]`."
             ) from exc
         self._model = SentenceTransformer(model_name)
+        self._model_name = model_name
         self._dim = int(self._model.get_sentence_embedding_dimension())
 
     async def embed(self, texts: list[str]) -> list[list[float]]:
@@ -119,6 +131,19 @@ class SentenceTransformerEmbedding(EmbeddingProvider):
 
     def dimension(self) -> int:
         return self._dim
+
+    async def embed_query(self, text: str) -> list[float]:
+        if "e5" in self._model_name.lower():
+            text = f"query: {text}"
+        return (await self.embed([text]))[0]
+
+    async def embed_documents(
+        self,
+        texts: list[str],
+    ) -> list[list[float]]:
+        if "e5" in self._model_name.lower():
+            texts = [f"passage: {text}" for text in texts]
+        return await self.embed(texts)
 
 
 class MockEmbedding(EmbeddingProvider):
@@ -156,26 +181,66 @@ class CachedEmbeddingProvider(EmbeddingProvider):
     def __init__(self, inner: EmbeddingProvider, maxsize: int = 2048) -> None:
         self._inner = inner
         self._maxsize = maxsize
-        self._cache: OrderedDict[str, list[float]] = OrderedDict()
+        self._cache: OrderedDict[
+            tuple[str, str],
+            list[float],
+        ] = OrderedDict()
 
     async def embed(self, texts: list[str]) -> list[list[float]]:
-        if self._maxsize <= 0 or not texts:
+        return await self._embed_kind("generic", texts)
+
+    async def embed_query(self, text: str) -> list[float]:
+        return (
+            await self._embed_kind("query", [text])
+        )[0]
+
+    async def embed_documents(
+        self,
+        texts: list[str],
+    ) -> list[list[float]]:
+        return await self._embed_kind("document", texts)
+
+    async def _embed_kind(
+        self,
+        kind: str,
+        texts: list[str],
+    ) -> list[list[float]]:
+        if not texts:
+            return []
+        if self._maxsize <= 0:
+            if kind == "query":
+                return [await self._inner.embed_query(texts[0])]
+            if kind == "document":
+                return await self._inner.embed_documents(texts)
             return await self._inner.embed(texts)
         missing: list[str] = []
         seen: set[str] = set()
         for text in texts:
-            if text in self._cache:
-                self._cache.move_to_end(text)
+            key = (kind, text)
+            if key in self._cache:
+                self._cache.move_to_end(key)
             elif text not in seen:
                 missing.append(text)
                 seen.add(text)
         if missing:
-            vectors = await self._inner.embed(missing)
+            if kind == "query":
+                vectors = list(
+                    await asyncio.gather(
+                        *[
+                            self._inner.embed_query(text)
+                            for text in missing
+                        ]
+                    )
+                )
+            elif kind == "document":
+                vectors = await self._inner.embed_documents(missing)
+            else:
+                vectors = await self._inner.embed(missing)
             for text, vector in zip(missing, vectors, strict=True):
-                self._cache[text] = vector
+                self._cache[(kind, text)] = vector
                 if len(self._cache) > self._maxsize:
                     self._cache.popitem(last=False)
-        return [self._cache[text] for text in texts]
+        return [self._cache[(kind, text)] for text in texts]
 
     def dimension(self) -> int:
         return self._inner.dimension()
@@ -190,6 +255,21 @@ class TimeoutEmbeddingProvider(EmbeddingProvider):
 
     async def embed(self, texts: list[str]) -> list[list[float]]:
         return await asyncio.wait_for(self._inner.embed(texts), timeout=self._timeout)
+
+    async def embed_query(self, text: str) -> list[float]:
+        return await asyncio.wait_for(
+            self._inner.embed_query(text),
+            timeout=self._timeout,
+        )
+
+    async def embed_documents(
+        self,
+        texts: list[str],
+    ) -> list[list[float]]:
+        return await asyncio.wait_for(
+            self._inner.embed_documents(texts),
+            timeout=self._timeout,
+        )
 
     def dimension(self) -> int:
         return self._inner.dimension()

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -105,6 +105,16 @@ retry against the primary. Unscoped/admin stores retain a global revision for
 compatibility; every scoped write bumps both its project revision and that
 global revision in the same transaction.
 
+Every vector row also carries `embedding_model_id` in addition to its
+dimension. Query/document roles are distinct in the provider API, so
+asymmetric retrieval models can apply the correct instructions without cache
+collisions. Stores index only the configured model and dimension.
+
+For databases created before this field existed, deploy this SDK while the old
+embedding model is still configured. Initialization labels matching legacy
+rows. Do not change model IDs until a backfill has produced the target vectors;
+same-dimensional vectors from two models are not interchangeable.
+
 ## Implementing your own store
 
 Subclass `contextdb.store.base.BaseStore`. You need `initialize`, `add`,

--- a/tests/unit/test_embeddings.py
+++ b/tests/unit/test_embeddings.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import pytest
 
 from contextdb.core.exceptions import ConfigError
-from contextdb.utils.embeddings import MockEmbedding, get_embedding_provider
+from contextdb.utils.embeddings import (
+    CachedEmbeddingProvider,
+    EmbeddingProvider,
+    MockEmbedding,
+    get_embedding_provider,
+)
 
 
 @pytest.mark.asyncio
@@ -33,3 +38,27 @@ def test_factory_routes_mock() -> None:
 def test_factory_unknown_model_raises() -> None:
     with pytest.raises((ConfigError, RuntimeError)):
         get_embedding_provider("a-random-name-that-does-not-exist")
+
+
+@pytest.mark.asyncio
+async def test_cache_separates_query_and_document_roles() -> None:
+    class RoleProvider(EmbeddingProvider):
+        async def embed(self, texts: list[str]) -> list[list[float]]:
+            return [[0.0] for _text in texts]
+
+        async def embed_query(self, text: str) -> list[float]:
+            return [1.0]
+
+        async def embed_documents(
+            self,
+            texts: list[str],
+        ) -> list[list[float]]:
+            return [[2.0] for _text in texts]
+
+        def dimension(self) -> int:
+            return 1
+
+    cached = CachedEmbeddingProvider(RoleProvider())
+    assert await cached.embed_query("same text") == [1.0]
+    assert await cached.embed_documents(["same text"]) == [[2.0]]
+    assert await cached.embed_query("same text") == [1.0]

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -75,6 +75,70 @@ async def test_consistency_versions_are_project_scoped(
 
 
 @pytest.mark.asyncio
+async def test_embedding_model_ids_prevent_same_dimension_mixing(
+    tmp_path: Path,
+) -> None:
+    url = f"sqlite:///{tmp_path}/embedding-models.db"
+    first = SQLiteStore(
+        url,
+        embedding_dim=2,
+        embedding_model_id="model-a",
+    )
+    second = SQLiteStore(
+        url,
+        embedding_dim=2,
+        embedding_model_id="model-b",
+    )
+    await first.initialize()
+    await second.initialize()
+    try:
+        memory_a = await first.add(
+            MemoryItem(content="a", embedding=[1.0, 0.0])
+        )
+        memory_b = await second.add(
+            MemoryItem(content="b", embedding=[0.0, 1.0])
+        )
+        hits_a = await first.search_by_embedding([1.0, 0.0])
+        hits_b = await second.search_by_embedding([0.0, 1.0])
+
+        assert memory_a.embedding_model_id == "model-a"
+        assert memory_b.embedding_model_id == "model-b"
+        assert [memory.id for memory in hits_a] == [memory_a.id]
+        assert [memory.id for memory in hits_b] == [memory_b.id]
+    finally:
+        await first.close()
+        await second.close()
+
+
+@pytest.mark.asyncio
+async def test_legacy_embedding_rows_are_labeled_before_cutover(
+    tmp_path: Path,
+) -> None:
+    url = f"sqlite:///{tmp_path}/legacy-embedding.db"
+    legacy = SQLiteStore(url, embedding_dim=2)
+    await legacy.initialize()
+    memory = await legacy.add(
+        MemoryItem(content="legacy", embedding=[1.0, 0.0])
+    )
+    await legacy.close()
+
+    versioned = SQLiteStore(
+        url,
+        embedding_dim=2,
+        embedding_model_id="legacy-model-v1",
+    )
+    await versioned.initialize()
+    try:
+        stored = await versioned.get_raw(memory.id)
+        assert stored is not None
+        assert stored.embedding_model_id == "legacy-model-v1"
+        hits = await versioned.search_by_embedding([1.0, 0.0])
+        assert [item.id for item in hits] == [memory.id]
+    finally:
+        await versioned.close()
+
+
+@pytest.mark.asyncio
 async def test_update_fields(tmp_store: SQLiteStore) -> None:
     item = MemoryItem(content="x", embedding=[0.0] * 32)
     stored = await tmp_store.add(item)


### PR DESCRIPTION
## Summary
- persist embedding_model_id with every vector
- reject writes from a different configured vector space
- index only the configured model and dimension
- label matching legacy rows before any model cutover
- add query/document embedding methods for asymmetric retrieval
- isolate query, document, and generic cache entries
- apply E5 query:/passage: prefixes through the role-aware provider

## Why
Same-dimensional vectors from different models are not compatible. This contract prevents silent mixing and creates a safe precondition for measured re-embedding/backfill.

## Verification
- 161 SDK unit/eval tests passed; 18 Postgres-dependent tests skipped locally
- model-isolation and legacy-label migration tests passed
- Ruff and Python 3.12 mypy passed

Made with [Cursor](https://cursor.com)