### PR TITLE
Carry retrieval roles over embedding transport

### DIFF
--- a/contextdb/client.py
+++ b/contextdb/client.py
@@ -148,7 +148,10 @@ class ContextDB:
         self._embedder = wrap_embedder(
             get_embedding_provider(
                 self.config.embedding_model,
-                self.config.llm_api_key,
+                (
+                    self.config.embedding_api_key
+                    or self.config.llm_api_key
+                ),
                 dimension=self.config.embedding_dim,
                 base_url=self.config.embedding_base_url,
             ),

--- a/contextdb/core/config.py
+++ b/contextdb/core/config.py
@@ -44,6 +44,13 @@ class ContextDBConfig(BaseSettings):
         default=1536,
         description="Embedding vector dimensionality; must match embedding_model.",
     )
+    embedding_api_key: str | None = Field(
+        default=None,
+        description=(
+            "Credential for the embedding provider. Falls back to llm_api_key "
+            "for backward compatibility."
+        ),
+    )
     llm_model: str = Field(
         default="gpt-4o-mini",
         description="LLM used for extraction, compression, and reasoning steps.",

--- a/contextdb/utils/embeddings.py
+++ b/contextdb/utils/embeddings.py
@@ -76,21 +76,56 @@ class OpenAIEmbedding(EmbeddingProvider):
         self._dim = _OPENAI_DIMS.get(model) or dim_override or 1536
 
     async def embed(self, texts: list[str]) -> list[list[float]]:
+        return await self._embed_role(texts, role=None)
+
+    async def embed_query(self, text: str) -> list[float]:
+        return (
+            await self._embed_role([text], role="query")
+        )[0]
+
+    async def embed_documents(
+        self,
+        texts: list[str],
+    ) -> list[list[float]]:
+        return await self._embed_role(texts, role="document")
+
+    async def _embed_role(
+        self,
+        texts: list[str],
+        *,
+        role: str | None,
+    ) -> list[list[float]]:
         if not texts:
             return []
         # OpenAI's per-call limit is 2048 inputs; chunk defensively.
         chunks = [texts[i : i + 2048] for i in range(0, len(texts), 2048)]
         out: list[list[float]] = []
         for chunk in chunks:
-            out.extend(await self._embed_with_retry(chunk))
+            out.extend(
+                await self._embed_with_retry(
+                    chunk,
+                    role=role,
+                )
+            )
         return out
 
-    async def _embed_with_retry(self, texts: list[str]) -> list[list[float]]:
+    async def _embed_with_retry(
+        self,
+        texts: list[str],
+        *,
+        role: str | None,
+    ) -> list[list[float]]:
         delay = 1.0
         for attempt in range(self.max_retries):
             try:
                 response = await self._client.embeddings.create(
-                    model=self.model, input=texts
+                    model=self.model,
+                    input=texts,
+                    extra_headers=(
+                        {"X-ContextDB-Embedding-Role": role}
+                        if role is not None
+                        else None
+                    ),
                 )
                 return [d.embedding for d in response.data]
             except Exception:  # noqa: BLE001

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -22,6 +22,7 @@ def test_defaults() -> None:
     assert cfg.storage_url == "sqlite:///contextdb.db"
     assert cfg.embedding_model == "text-embedding-3-small"
     assert cfg.embedding_dim == 1536
+    assert cfg.embedding_api_key is None
     assert cfg.llm_model == "gpt-4o-mini"
     assert cfg.pii_action == "redact"
     assert cfg.retention_ttl_days == 730
@@ -46,9 +47,14 @@ def test_api_key_none_when_nothing_set(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_reads_from_contextdb_env_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CONTEXTDB_STORAGE_URL", "postgresql://localhost/ctx")
     monkeypatch.setenv("CONTEXTDB_LOG_LEVEL", "DEBUG")
+    monkeypatch.setenv(
+        "CONTEXTDB_EMBEDDING_API_KEY",
+        "embedding-secret",
+    )
     cfg = ContextDBConfig(llm_api_key="x")
     assert cfg.storage_url == "postgresql://localhost/ctx"
     assert cfg.log_level == "DEBUG"
+    assert cfg.embedding_api_key == "embedding-secret"
 
 
 def test_exception_hierarchy() -> None:

--- a/tests/unit/test_embeddings.py
+++ b/tests/unit/test_embeddings.py
@@ -9,6 +9,7 @@ from contextdb.utils.embeddings import (
     CachedEmbeddingProvider,
     EmbeddingProvider,
     MockEmbedding,
+    OpenAIEmbedding,
     get_embedding_provider,
 )
 
@@ -62,3 +63,25 @@ async def test_cache_separates_query_and_document_roles() -> None:
     assert await cached.embed_query("same text") == [1.0]
     assert await cached.embed_documents(["same text"]) == [[2.0]]
     assert await cached.embed_query("same text") == [1.0]
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_transport_forwards_embedding_role() -> None:
+    provider = object.__new__(OpenAIEmbedding)
+    calls: list[tuple[list[str], str | None]] = []
+
+    async def fake_embed(
+        texts: list[str],
+        *,
+        role: str | None,
+    ) -> list[list[float]]:
+        calls.append((texts, role))
+        return [[1.0] for _text in texts]
+
+    provider._embed_with_retry = fake_embed  # type: ignore[method-assign]
+    assert await provider.embed_query("query") == [1.0]
+    assert await provider.embed_documents(["document"]) == [[1.0]]
+    assert calls == [
+        (["query"], "query"),
+        (["document"], "document"),
+    ]


### PR DESCRIPTION
## Summary
- send query/document roles to OpenAI-compatible embedding services
- keep role-specific cache entries isolated
- add a dedicated embedding_api_key with backward-compatible LLM-key fallback
- preserve unchanged behavior for OpenAI providers that ignore the role header

## Why
The measured local winner is an asymmetric E5 model: queries require `query:` and stored memories require `passage:`. The transport must preserve that role or quality drops.

## Verification
- embedding/config/init suites passed
- role forwarding and cache isolation tests passed
- Ruff and Python 3.12 mypy passed

Made with [Cursor](https://cursor.com)