### PR TITLE
Allow hosts to share embedding providers

### DIFF
--- a/contextdb/__init__.py
+++ b/contextdb/__init__.py
@@ -31,6 +31,7 @@ from contextdb.core.models import (
 )
 from contextdb.core.policy import TrustPolicy
 from contextdb.pool import ContextDBPool
+from contextdb.utils.embeddings import EmbeddingProvider
 
 __version__ = "0.3.1"
 
@@ -42,6 +43,7 @@ __all__ = [
     "ContextDBError",
     "ContextDBPool",
     "Edge",
+    "EmbeddingProvider",
     "Entity",
     "FrozenClock",
     "MemoryItem",
@@ -75,6 +77,7 @@ def init(
     clock: Clock | None = None,
     trust_policy: TrustPolicy | None = None,
     postgres_pool: Any | None = None,
+    embedding_provider: EmbeddingProvider | None = None,
     **kwargs: Any,
 ) -> ContextDB:
     """Create a :class:`ContextDB` client.
@@ -91,6 +94,8 @@ def init(
             ``CONTEXTDB_``.
         postgres_pool: Optional externally owned asyncpg pool. Valid only with
             a PostgreSQL ``storage_url``. ContextDB never closes this pool.
+        embedding_provider: Optional externally owned provider shared by the
+            host. ContextDB uses but never closes this provider.
         **kwargs: Forwarded to :class:`ContextDBConfig` if ``config`` is
             not provided.
 
@@ -107,4 +112,5 @@ def init(
         clock=clock,
         trust_policy=trust_policy,
         postgres_pool=postgres_pool,
+        embedding_provider=embedding_provider,
     )

--- a/contextdb/client.py
+++ b/contextdb/client.py
@@ -80,6 +80,7 @@ class ContextDB:
         clock: Clock | None = None,
         trust_policy: TrustPolicy | None = None,
         postgres_pool: Any | None = None,
+        embedding_provider: EmbeddingProvider | None = None,
     ) -> None:
         self.config = config
         self.user_id = user_id
@@ -94,7 +95,8 @@ class ContextDB:
         self._postgres_pool = postgres_pool
         self._store: BaseStore | None = None
         self._hooks: dict[str, list[Callable[..., Any]]] = {}
-        self._embedder: EmbeddingProvider | None = None
+        self._embedder: EmbeddingProvider | None = embedding_provider
+        self._owns_embedder = embedding_provider is None
         self._llm: LLMProvider | None = None
         self._pii: PIIDetector | None = None
         self._graphs: dict[str, BaseGraph] = {}
@@ -145,19 +147,20 @@ class ContextDB:
         if self._initialized:
             return
         # Core building blocks
-        self._embedder = wrap_embedder(
-            get_embedding_provider(
-                self.config.embedding_model,
-                (
-                    self.config.embedding_api_key
-                    or self.config.llm_api_key
+        if self._embedder is None:
+            self._embedder = wrap_embedder(
+                get_embedding_provider(
+                    self.config.embedding_model,
+                    (
+                        self.config.embedding_api_key
+                        or self.config.llm_api_key
+                    ),
+                    dimension=self.config.embedding_dim,
+                    base_url=self.config.embedding_base_url,
                 ),
-                dimension=self.config.embedding_dim,
-                base_url=self.config.embedding_base_url,
-            ),
-            cache_size=self.config.embedding_cache_size,
-            timeout_seconds=self.config.embed_timeout_seconds,
-        )
+                cache_size=self.config.embedding_cache_size,
+                timeout_seconds=self.config.embed_timeout_seconds,
+            )
         dim = self._embedder.dimension()
         self._store = open_store(
             self.config.storage_url,
@@ -1579,6 +1582,10 @@ class ContextDB:
             self._consolidation_task = None
         if self._store is not None:
             await self._store.close()
+            self._store = None
+        if self._owns_embedder and self._embedder is not None:
+            await self._embedder.close()
+            self._embedder = None
         self._initialized = False
 
     async def __aenter__(self) -> ContextDB:

--- a/contextdb/utils/embeddings.py
+++ b/contextdb/utils/embeddings.py
@@ -46,6 +46,10 @@ class EmbeddingProvider(ABC):
         """Embed stored memory/document text."""
         return await self.embed(texts)
 
+    async def close(self) -> None:
+        """Release provider resources. Default providers own none."""
+        return None
+
 
 class OpenAIEmbedding(EmbeddingProvider):
     """OpenAI embedding API wrapper with exponential-backoff retry.
@@ -137,6 +141,9 @@ class OpenAIEmbedding(EmbeddingProvider):
 
     def dimension(self) -> int:
         return self._dim
+
+    async def close(self) -> None:
+        await self._client.close()
 
 
 class SentenceTransformerEmbedding(EmbeddingProvider):
@@ -280,6 +287,9 @@ class CachedEmbeddingProvider(EmbeddingProvider):
     def dimension(self) -> int:
         return self._inner.dimension()
 
+    async def close(self) -> None:
+        await self._inner.close()
+
 
 class TimeoutEmbeddingProvider(EmbeddingProvider):
     """Fail an embedding call after ``timeout_seconds`` so voice turns can degrade."""
@@ -308,6 +318,9 @@ class TimeoutEmbeddingProvider(EmbeddingProvider):
 
     def dimension(self) -> int:
         return self._inner.dimension()
+
+    async def close(self) -> None:
+        await self._inner.close()
 
 
 def wrap_embedder(

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 import contextdb
 
 
@@ -29,3 +31,51 @@ def test_public_exports_present() -> None:
         "init",
     }
     assert expected.issubset(set(contextdb.__all__))
+
+
+@pytest.mark.asyncio
+async def test_hosts_can_share_one_embedding_provider() -> None:
+    class SharedProvider(contextdb.EmbeddingProvider):
+        def __init__(self) -> None:
+            self.calls = 0
+            self.closed = 0
+
+        async def embed(self, texts: list[str]) -> list[list[float]]:
+            self.calls += 1
+            return [[1.0, 0.0] for _text in texts]
+
+        def dimension(self) -> int:
+            return 2
+
+        async def close(self) -> None:
+            self.closed += 1
+
+    provider = SharedProvider()
+    first = contextdb.init(
+        user_id="first",
+        storage_url="sqlite:///:memory:",
+        embedding_model="shared-test",
+        embedding_dim=2,
+        llm_model="mock",
+        llm_api_key="mock",
+        embedding_provider=provider,
+    )
+    second = contextdb.init(
+        user_id="second",
+        storage_url="sqlite:///:memory:",
+        embedding_model="shared-test",
+        embedding_dim=2,
+        llm_model="mock",
+        llm_api_key="mock",
+        embedding_provider=provider,
+    )
+    try:
+        await first.factual.add("first", source="user_stated")
+        await second.factual.add("second", source="user_stated")
+    finally:
+        await first.close()
+        await second.close()
+    assert provider.calls == 2
+    assert provider.closed == 0
+    await provider.close()
+    assert provider.closed == 1


### PR DESCRIPTION
## Summary
- accept an externally owned embedding provider in contextdb.init
- reuse one HTTP client/cache across project runtimes
- add explicit provider close semantics
- keep external providers alive when project runtimes are evicted
- close SDK-owned providers during client shutdown

## Why
Per-project OpenAI-compatible clients made each cold project pay transport initialization even when the embedding service was warm. Host ownership moves that cost to one startup probe.

## Verification
- 163 unit/eval tests passed; 18 Postgres-dependent tests skipped locally
- shared ownership/lifetime test passed
- Ruff and Python 3.12 mypy passed

Made with [Cursor](https://cursor.com)