### PR TITLE
Enforce the open-core constitution

### DIFF
--- a/.cursor/rules/open-core-boundary.mdc
+++ b/.cursor/rules/open-core-boundary.mdc
@@ -1,0 +1,34 @@
+---
+description: Binding ContextDB open-core placement rule
+alwaysApply: true
+---
+
+# Open-Core Boundary
+
+Canonical source: `OPEN_CORE.md`.
+
+> Open the single-node semantics and reference engine. Keep multi-tenant
+> coordination, operated guarantees, governance, and proof private.
+
+Before editing, classify the change:
+
+0. **No capability change** — docs/tests/build/maintenance only.
+1. **Semantic** — offline correctness: open implementation here.
+2. **Contract** — interface/schema/protocol: open here.
+3. **Reference** — minimal single-node implementation: open here.
+4. **Operated** — tenants/processes/regions/people/SLAs: private Cloud.
+
+For mixed features, add only the contract and minimal reference. Do not add the
+production coordinator, scheduler, controller, managed worker, migrations,
+deployment topology, or operations.
+
+Never add:
+
+- imports of `contextdb_cloud`;
+- paid flags, license keys, phone-home, or weaker safety;
+- hosted auth, entitlements, billing, organization control plane, enterprise
+  governance, managed service, deployment, or fleet code;
+- ambiguous functionality without explicit boundary review.
+
+Existing Apache grants are permanent. Private code can be opened later; an
+Apache grant cannot be clawed back.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,9 +2,27 @@
 
 <!-- What changed, and why. Evals win over prose. -->
 
+## Open-core classification
+
+Select exactly one and justify placement against `OPEN_CORE.md`.
+
+- [ ] No capability change — docs/tests/build/maintenance only.
+- [ ] Semantic — portable offline correctness.
+- [ ] Contract — interface/schema/protocol.
+- [ ] Reference — minimal single-node implementation.
+- [ ] Operated — multi-tenant/process/region/people/SLA coordination; this PR
+      does not belong in the public SDK.
+
+**Why this repository is the correct side of the boundary:**
+
+<!-- For mixed features, identify the open contract and private implementation. -->
+
 ## Checklist
 
 - [ ] `pytest tests/evals/ -v` passes, or I explain why not.
+- [ ] `python scripts/check_open_core_boundary.py` passes.
 - [ ] `contextdb.init`, `factual.add`, `factual.recall`, and `search` keep working; new fields have backward-compatible defaults.
 - [ ] No new runtime dependency without a discussion first.
+- [ ] No hosted auth, entitlements, billing, control-plane, enterprise,
+      deployment, migration-orchestration, or fleet code entered the SDK.
 - [ ] Substantial contribution: I agree to the CLA in CONTRIBUTING.md (legal name and email in this description). Trivial typo PRs may skip this.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
+      - name: Open-core boundary
+        run: python scripts/check_open_core_boundary.py
+
       - name: Lint with ruff
         run: ruff check .
 

--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -26,9 +26,13 @@ You may not, without a commercial agreement with Atoms AI:
 
 ## Resale and commercial agreements
 
-If your company resells ContextDB as a service or as part of a service,
-or wants OEM/embedded licensing, support, or a trademark arrangement,
-contact **contextdb@atomsai.com** before you ship.
+Apache-2.0 permits commercial use, modification, redistribution, embedding,
+and hosted use of the code, subject to its terms. No separate copyright
+license is required for those uses.
+
+If your company wants to use the ContextDB name or logo for a hosted offering,
+or wants a supported OEM arrangement, Cloud service, support, or a trademark
+agreement, contact **contextdb@atomsai.com**.
 
 ## Attribution (optional)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,10 @@ gates.
 ## What we accept here
 
 Trust and safety correctness, local runtime fixes, adapters, docs, and
-evals. Evals win over prose: `pytest tests/evals/ -v`.
+evals. Portable contracts and minimal single-node reference implementations
+also belong here. Classify every substantial change under
+[OPEN_CORE.md](OPEN_CORE.md). Evals win over prose:
+`pytest tests/evals/ -v`.
 
 We do **not** accept:
 
@@ -15,6 +18,9 @@ We do **not** accept:
   no flags that only work against a hosted service
 - Imports of packages outside the declared dependencies
 - Changes that loosen PII-before-embed or the hash-chained audit log
+- Hosted auth, tenancy, entitlements, billing, organization control-plane,
+  enterprise governance, managed-service, deployment, migration-orchestration,
+  or fleet code
 
 ## Contributor License Agreement
 

--- a/OPEN_CORE.md
+++ b/OPEN_CORE.md
@@ -1,0 +1,80 @@
+# ContextDB open-core constitution
+
+**Status: binding for all future work.** Changes require an explicit
+architecture decision and maintainer approval.
+
+> Open the single-node semantics and reference engine. Keep multi-tenant coordination, operated guarantees, governance, and proof private.
+
+This repository is the public Apache-2.0 engine. It must remain complete,
+useful offline, inspectable, and safe without a hosted account, license key,
+paid flag, time bomb, or phone-home.
+
+Existing Apache grants are permanent. New code is reviewed prospectively
+against this constitution before merge and again before package publication.
+
+## Four change classes
+
+Every capability-changing contribution is classified as exactly one:
+
+1. **Semantic** — portable correctness required offline: open implementation.
+2. **Contract** — interface, schema, protocol, or compatibility test: open.
+3. **Reference** — minimal single-node implementation proving a contract: open.
+4. **Operated** — coordinates tenants, processes, regions, people, or an SLA:
+   private Cloud implementation, not this repository.
+
+Docs, tests, and maintenance with no capability change declare that explicitly.
+Mixed features are split. This repository may contain the contract and minimal
+reference implementation. Distributed schedulers, controllers, managed
+workers, deployment topology, and operations stay private.
+
+## What belongs here
+
+- Memory and epistemic data models.
+- `TrustPolicy`, act/ask/abstain, confirmation, and local explanation.
+- PII-before-embed, injection defenses, and public adversarial evals.
+- Local CRUD, SQLite, and a basic Postgres reference adapter.
+- Atomic mutation/version/audit behavior required for correct storage.
+- Deletion semantics and local verification.
+- Portable consistency-token, embedding-provider, and connector contracts.
+- Minimal reference implementations and compatibility tests.
+
+Safety and correctness are never commercially gated or intentionally weaker
+than the hosted service.
+
+## What does not belong here
+
+- Hosted gateway, tenancy, API-key auth, entitlements, quotas, billing, or
+  abuse controls.
+- Organization/project/team control plane or governance console.
+- Multi-worker routing, replica orchestration, failover, autoscaling, backups,
+  incidents, or availability guarantees.
+- Managed model fleet, batching service, backfill control, or deployment code.
+- Managed connector sync, checkpoints, retries, observability, or support SLAs.
+- Organization Action Ledger, signed compliance exports, or retention service.
+- Policy rollout/canary/approval controllers.
+- SSO, SCIM, KMS/BYOK, private networking, residency, or contractual controls.
+
+Thin generated Cloud clients, public API schemas, connector interfaces, and
+common community adapters are public distribution artifacts because they grow
+the ecosystem; they may live in separate public packages and contain no hosted
+implementation.
+
+## Contribution and release gate
+
+- Pull requests declare one change class and justify repository placement.
+- Ambiguous changes stop for boundary review; publication is never the default.
+- Contract tests may be shared; private implementations are not copied here.
+- Every PyPI release receives an open-core diff review.
+- `scripts/check_open_core_boundary.py` and CI enforce mechanical invariants.
+
+Private code can be opened later. An Apache grant cannot be clawed back.
+
+## Commercial model
+
+ContextDB Cloud sells operation, coordination, governance, and proof of this
+open correctness model. The SDK is not a crippled free tier. If Cloud cannot
+win while this engine is useful, Cloud must become stronger rather than making
+the SDK weaker.
+
+See [COMMERCIAL.md](COMMERCIAL.md) for trademark rules. Apache-2.0 permits
+commercial use of the code; it does not grant rights to ContextDB trademarks.

--- a/README.md
+++ b/README.md
@@ -562,7 +562,9 @@ this README ships in this tree, with no feature gates. **ContextDB** is a
 trademark; the Apache license is not a trademark license. Reselling
 ContextDB as a service, or as part of one, under the ContextDB name or
 branding requires a commercial agreement with Atoms AI — contact
-contextdb@atomsai.com (see [COMMERCIAL.md](https://github.com/atomsai/contextdb/blob/main/COMMERCIAL.md)). A public
+contextdb@atomsai.com (see [COMMERCIAL.md](https://github.com/atomsai/contextdb/blob/main/COMMERCIAL.md)).
+The binding product boundary is documented in
+[OPEN_CORE.md](https://github.com/atomsai/contextdb/blob/main/OPEN_CORE.md). A public
 credit line is optional — if you want one, use **Built with ContextDB**
 linking to this repository.
 

--- a/scripts/check_open_core_boundary.py
+++ b/scripts/check_open_core_boundary.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Mechanical checks for the binding ContextDB open-core constitution."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CANONICAL = (
+    "Open the single-node semantics and reference engine. Keep multi-tenant "
+    "coordination, operated guarantees, governance, and proof private."
+)
+FORBIDDEN_SOURCE_PARTS = {
+    "billing",
+    "cloud",
+    "console",
+    "control_plane",
+    "enterprise",
+    "entitlements",
+    "private_link",
+    "residency",
+    "scim",
+    "sso",
+}
+FORBIDDEN_RUNTIME_TOKENS = {
+    "CONTEXTDB_LICENSE_KEY",
+    "enterprise_only",
+    "if_paid",
+    "requires_entitlement",
+    "subscription_tier",
+}
+
+
+def _normalized(path: Path) -> str:
+    return " ".join(path.read_text(encoding="utf-8").split())
+
+
+def check_source_tree(source: Path) -> list[str]:
+    errors: list[str] = []
+    for path in source.rglob("*.py"):
+        relative = path.relative_to(source)
+        lowered_parts = {part.lower() for part in relative.parts}
+        denied_parts = sorted(lowered_parts & FORBIDDEN_SOURCE_PARTS)
+        if denied_parts:
+            errors.append(
+                f"private capability path in SDK: {relative} "
+                f"({', '.join(denied_parts)})"
+            )
+        text = path.read_text(encoding="utf-8")
+        for token in sorted(FORBIDDEN_RUNTIME_TOKENS):
+            if token in text:
+                errors.append(f"commercial gate token {token!r} in {relative}")
+        try:
+            tree = ast.parse(text, filename=str(path))
+        except SyntaxError as exc:
+            errors.append(f"cannot parse {relative}: {exc}")
+            continue
+        for node in ast.walk(tree):
+            names: list[str]
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                names = [node.module]
+            else:
+                continue
+            if any(
+                name == "contextdb_cloud"
+                or name.startswith("contextdb_cloud.")
+                for name in names
+            ):
+                errors.append(f"SDK imports private Cloud code: {relative}")
+    return errors
+
+
+def check_root(root: Path) -> list[str]:
+    errors: list[str] = []
+    constitution = root / "OPEN_CORE.md"
+    rule = root / ".cursor" / "rules" / "open-core-boundary.mdc"
+    template = root / ".github" / "pull_request_template.md"
+    required = (constitution, rule, template)
+    for path in required:
+        if not path.is_file():
+            errors.append(f"boundary artifact missing: {path.relative_to(root)}")
+    if constitution.is_file() and CANONICAL not in _normalized(constitution):
+        errors.append("OPEN_CORE.md is missing the canonical boundary sentence")
+    if rule.is_file() and "alwaysApply: true" not in rule.read_text(
+        encoding="utf-8"
+    ):
+        errors.append("open-core Cursor rule must always apply")
+    if template.is_file():
+        text = template.read_text(encoding="utf-8")
+        for change_class in ("Semantic", "Contract", "Reference", "Operated"):
+            if change_class not in text:
+                errors.append(
+                    f"pull-request template omits {change_class} classification"
+                )
+    pyproject = root / "pyproject.toml"
+    if pyproject.is_file() and 'license = "Apache-2.0"' not in pyproject.read_text(
+        encoding="utf-8"
+    ):
+        errors.append("public SDK project license must remain Apache-2.0")
+    errors.extend(check_source_tree(root / "contextdb"))
+    return errors
+
+
+def main() -> int:
+    errors = check_root(ROOT)
+    if errors:
+        print("open-core boundary check FAILED", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print("open-core boundary check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -4,6 +4,7 @@
 Run before publishing (the publish workflow runs it on every release):
 
 * the release tag must match the version in ``pyproject.toml``;
+* the open-core constitution and source boundary must pass;
 * the sdist and wheel must contain ``LICENSE`` and ``NOTICE``;
 * the archives must not contain secrets, key material, virtualenvs, or
   other scratch files (see the denylist below).
@@ -13,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import subprocess
 import sys
 import tarfile
 import zipfile
@@ -137,8 +139,22 @@ def check_release_tag(tag: str) -> list[str]:
     return []
 
 
+def check_open_core_boundary() -> list[str]:
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "check_open_core_boundary.py")],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return []
+    detail = (result.stderr or result.stdout).strip()
+    return [f"open-core boundary check failed: {detail}"]
+
+
 def run(dist: Path | None, release_tag: str | None) -> int:
-    errors: list[str] = []
+    errors: list[str] = check_open_core_boundary()
     if dist is not None:
         errors.extend(check_dist(dist))
     if release_tag:

--- a/tests/unit/test_open_core_boundary.py
+++ b/tests/unit/test_open_core_boundary.py
@@ -1,0 +1,53 @@
+"""Open-core boundary checks stay executable and detect private imports."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECK = ROOT / "scripts" / "check_open_core_boundary.py"
+
+
+def _module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("open_core_check", CHECK)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_open_core_boundary_script() -> None:
+    result = subprocess.run(
+        [sys.executable, str(CHECK)],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_private_cloud_import_is_rejected(tmp_path: Path) -> None:
+    source = tmp_path / "contextdb"
+    source.mkdir()
+    (source / "leak.py").write_text(
+        "from contextdb_cloud.gateway import app\n",
+        encoding="utf-8",
+    )
+    errors = _module().check_source_tree(source)
+    assert any("imports private Cloud code" in error for error in errors)
+
+
+def test_commercial_gate_path_is_rejected(tmp_path: Path) -> None:
+    source = tmp_path / "contextdb"
+    (source / "billing").mkdir(parents=True)
+    (source / "billing" / "plans.py").write_text(
+        "PLAN = 'enterprise'\n",
+        encoding="utf-8",
+    )
+    errors = _module().check_source_tree(source)
+    assert any("private capability path" in error for error in errors)


### PR DESCRIPTION
## Summary
- define the Apache engine boundary and permanent licensing posture
- require every capability change to be classified before review
- block private Cloud paths, imports, and commercial gate tokens from SDK source
- make CI and PyPI release checks enforce the constitution
- correct commercial-use guidance while preserving ContextDB trademark controls

## Open-core classification
- [x] No capability change — governance, legal clarity, tests, and release enforcement only

## Verification
- `python scripts/check_open_core_boundary.py`
- 166 unit/eval tests passed; 18 Postgres-dependent tests skipped locally
- Ruff and Python 3.12 mypy passed
- `python scripts/check_release.py --release-tag v0.3.1`

Made with [Cursor](https://cursor.com)