### PR TITLE
Require SDK PR boundary classification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
 
       - name: Open-core boundary
         run: python scripts/check_open_core_boundary.py
+        env:
+          CONTEXTDB_REQUIRE_PR_CLASSIFICATION: ${{ github.event_name == 'pull_request' }}
+          CONTEXTDB_PR_BODY: ${{ github.event.pull_request.body }}
 
       - name: Lint with ruff
         run: ruff check .

--- a/scripts/check_open_core_boundary.py
+++ b/scripts/check_open_core_boundary.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import ast
+import os
+import re
 import sys
 from pathlib import Path
 
@@ -11,6 +13,13 @@ ROOT = Path(__file__).resolve().parents[1]
 CANONICAL = (
     "Open the single-node semantics and reference engine. Keep multi-tenant "
     "coordination, operated guarantees, governance, and proof private."
+)
+CHANGE_CLASSES = (
+    "No capability change",
+    "Semantic",
+    "Contract",
+    "Reference",
+    "Operated",
 )
 FORBIDDEN_SOURCE_PARTS = {
     "billing",
@@ -35,6 +44,25 @@ FORBIDDEN_RUNTIME_TOKENS = {
 
 def _normalized(path: Path) -> str:
     return " ".join(path.read_text(encoding="utf-8").split())
+
+
+def check_pr_classification(body: str) -> list[str]:
+    selected = [
+        change_class
+        for change_class in CHANGE_CLASSES
+        if re.search(
+            rf"-\s*\[[xX]\]\s*{re.escape(change_class)}\b",
+            body,
+        )
+    ]
+    if len(selected) != 1:
+        return [
+            "select exactly one open-core classification in the PR body; "
+            f"found {len(selected)}"
+        ]
+    if selected[0] == "Operated":
+        return ["Operated changes belong in private Cloud, not the public SDK"]
+    return []
 
 
 def check_source_tree(source: Path) -> list[str]:
@@ -107,6 +135,12 @@ def check_root(root: Path) -> list[str]:
 
 def main() -> int:
     errors = check_root(ROOT)
+    if os.environ.get("CONTEXTDB_REQUIRE_PR_CLASSIFICATION") == "true":
+        errors.extend(
+            check_pr_classification(
+                os.environ.get("CONTEXTDB_PR_BODY", "")
+            )
+        )
     if errors:
         print("open-core boundary check FAILED", file=sys.stderr)
         for error in errors:

--- a/tests/unit/test_open_core_boundary.py
+++ b/tests/unit/test_open_core_boundary.py
@@ -51,3 +51,14 @@ def test_commercial_gate_path_is_rejected(tmp_path: Path) -> None:
     )
     errors = _module().check_source_tree(source)
     assert any("private capability path" in error for error in errors)
+
+
+def test_sdk_pr_requires_one_non_operated_classification() -> None:
+    check = _module().check_pr_classification
+    assert check("- [x] Semantic — offline correctness") == []
+    assert check("- [X] Contract — interface") == []
+    assert check("- [x] Reference — single node") == []
+    assert check("- [x] No capability change — docs") == []
+    assert check("") != []
+    assert check("- [x] Semantic\n- [x] Contract") != []
+    assert check("- [x] Operated — hosted behavior") != []


### PR DESCRIPTION
## Summary
- require exactly one open-core class on every pull request
- allow semantic, contract, reference, and no-capability SDK changes
- reject operated Cloud capabilities from the Apache repository
- test empty, multiple, valid, and wrong-side classifications

## Open-core classification
- [x] No capability change — CI enforcement only.

## Verification
- classification-aware open-core check passed
- boundary tests passed
- Ruff passed

Made with [Cursor](https://cursor.com)