### PR TITLE
Release ContextDB SDK 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## Unreleased
 
+## 0.3.2 — 2026-08-20
+
+### Added
+
+- Host-owned asyncpg pools and embedding providers can be shared safely across
+  project runtimes without being closed on runtime eviction.
+- Mutations return project-scoped memory versions and Postgres WAL positions;
+  reads can require those floors and fail closed when unavailable.
+- Embeddings carry model identity and distinct query/document roles, including
+  role-aware OpenAI-compatible transport.
+- Project-scoped vector and immutable item caches remove redundant warm recall
+  queries while preserving user isolation and cross-worker coherence.
+- A durable read-audit hook lets hosted runtimes persist exact PII-processed
+  recall evidence outside the synchronous SDK audit chain.
+- The open-core constitution, PR classification, CI source scanner, and release
+  gate prevent operated Cloud capabilities from entering the Apache package.
+
+### Fixed
+
+- Memory mutation, project/global revision changes, and write audit now commit
+  in one Postgres transaction.
+- Advisory locks execute their protected work on the same transaction-bound
+  connection instead of accidentally hopping pool connections.
+- Public commercial-use guidance now matches Apache-2.0 while preserving
+  ContextDB trademark controls.
+
+`contextdb.init`, `factual.add`, `factual.recall`, and `search` remain
+backward-compatible. All new host-sharing and consistency arguments are
+optional.
+
 ## 0.3.1 — 2026-08-18
 
 ### Fixed

--- a/contextdb/__init__.py
+++ b/contextdb/__init__.py
@@ -33,7 +33,7 @@ from contextdb.core.policy import TrustPolicy
 from contextdb.pool import ContextDBPool
 from contextdb.utils.embeddings import EmbeddingProvider
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 __all__ = [
     "Clock",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pycontextdb"
-version = "0.3.1"
+version = "0.3.2"
 description = "The unified context layer for AI agents — memory you can act on without treating wishes as facts"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- bump the SDK and package version to 0.3.2
- document shared host resources, consistency tokens, scoped retrieval, embedding roles, and boundary enforcement
- preserve the already-public v0.3.1 tag instead of moving it

## Open-core classification
- [x] No capability change — release metadata and changelog only.

## Verification
- 168 unit/eval/version tests passed; 18 Postgres-dependent tests skipped locally
- Ruff and Python 3.12 mypy passed
- wheel and sdist built successfully
- release package inspection passed for `v0.3.2`

Made with [Cursor](https://cursor.com)