### PR TITLE
Add the public connector contract and Postgres reader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,5 +105,6 @@ jobs:
         run: |
           pytest \
             tests/unit/test_postgres_concurrency.py \
+            tests/unit/test_postgres_connector.py \
             tests/unit/test_scoped_id_access.py \
             tests/unit/test_vector_scope.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Public connector contracts plus a minimal local PostgreSQL/Supabase reader
+  with stable timestamp-plus-key cursors and soft-delete mapping. Hosts retain
+  control of credentials, scheduling, retries, and memory writes.
+
 ## 0.3.2 — 2026-08-20
 
 ### Added

--- a/contextdb/connectors/__init__.py
+++ b/contextdb/connectors/__init__.py
@@ -1,0 +1,25 @@
+"""Portable connector contracts and local reference adapters."""
+
+from contextdb.connectors.base import (
+    ConnectorConfigError,
+    ConnectorCursor,
+    ConnectorError,
+    ConnectorReader,
+    ConnectorRecord,
+    ConnectorSourceError,
+)
+from contextdb.connectors.postgres import (
+    PostgresConnector,
+    PostgresConnectorConfig,
+)
+
+__all__ = [
+    "ConnectorConfigError",
+    "ConnectorCursor",
+    "ConnectorError",
+    "ConnectorReader",
+    "ConnectorRecord",
+    "ConnectorSourceError",
+    "PostgresConnector",
+    "PostgresConnectorConfig",
+]

--- a/contextdb/connectors/base.py
+++ b/contextdb/connectors/base.py
@@ -1,0 +1,62 @@
+"""Portable connector contracts for local and hosted ingestion."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Protocol
+
+
+class ConnectorError(Exception):
+    """Base connector failure."""
+
+
+class ConnectorConfigError(ConnectorError):
+    """Source configuration or mapping is invalid."""
+
+
+class ConnectorSourceError(ConnectorError):
+    """Source is unavailable or rejects access."""
+
+
+@dataclass(frozen=True)
+class ConnectorCursor:
+    """Stable timestamp-plus-key cursor; timestamp alone can skip ties."""
+
+    updated_at: datetime
+    primary_key: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "updated_at": self.updated_at.isoformat(),
+            "primary_key": self.primary_key,
+        }
+
+
+@dataclass(frozen=True)
+class ConnectorRecord:
+    """One source record after mapping, before memory formation."""
+
+    source_key: str
+    source_version: str
+    user_id: str
+    content: str
+    updated_at: datetime
+    deleted: bool = False
+    provenance: dict[str, Any] = field(default_factory=dict)
+
+
+class ConnectorReader(Protocol):
+    """Read-only source contract. Scheduling and sinks are host concerns."""
+
+    async def validate(self) -> None: ...
+
+    async def preview(self, *, limit: int = 50) -> list[ConnectorRecord]: ...
+
+    def records(
+        self,
+        *,
+        cursor: ConnectorCursor | None = None,
+        limit: int = 100_000,
+    ) -> AsyncIterator[list[ConnectorRecord]]: ...

--- a/contextdb/connectors/postgres.py
+++ b/contextdb/connectors/postgres.py
@@ -1,0 +1,243 @@
+"""Minimal local PostgreSQL/Supabase connector reference."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import urlparse
+
+from contextdb.connectors.base import (
+    ConnectorConfigError,
+    ConnectorCursor,
+    ConnectorRecord,
+    ConnectorSourceError,
+)
+
+_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
+
+
+def _quoted(identifier: str) -> str:
+    if not _IDENTIFIER.fullmatch(identifier):
+        raise ConnectorConfigError(
+            f"invalid PostgreSQL identifier: {identifier!r}"
+        )
+    return f'"{identifier}"'
+
+
+def _relation(value: str) -> str:
+    parts = value.split(".")
+    if len(parts) not in {1, 2}:
+        raise ConnectorConfigError(
+            "relation must be a table/view name with optional schema"
+        )
+    return ".".join(_quoted(part) for part in parts)
+
+
+@dataclass(frozen=True)
+class PostgresConnectorConfig:
+    dsn: str
+    relation: str
+    primary_key: str
+    user_id: str
+    content: str
+    updated_at: str
+    deleted_at: str | None = None
+    page_size: int = 100
+    ssl_mode: str = "require"
+
+    def validate(self) -> None:
+        if urlparse(self.dsn).scheme not in {"postgres", "postgresql"}:
+            raise ConnectorConfigError("dsn must use postgres/postgresql")
+        if self.ssl_mode not in {
+            "disable",
+            "require",
+            "verify-ca",
+            "verify-full",
+        }:
+            raise ConnectorConfigError("unsupported PostgreSQL ssl_mode")
+        if not 1 <= self.page_size <= 1_000:
+            raise ConnectorConfigError("page_size must be between 1 and 1000")
+        _relation(self.relation)
+        for identifier in (
+            self.primary_key,
+            self.user_id,
+            self.content,
+            self.updated_at,
+        ):
+            _quoted(identifier)
+        if self.deleted_at:
+            _quoted(self.deleted_at)
+
+
+class PostgresConnector:
+    """Read mapped records locally; hosts own retries, secrets, and writes."""
+
+    def __init__(self, config: PostgresConnectorConfig) -> None:
+        config.validate()
+        self.config = config
+
+    async def _connect(self) -> Any:
+        try:
+            import asyncpg
+        except ImportError as exc:  # pragma: no cover - optional extra
+            raise ConnectorConfigError(
+                "Postgres connector requires pycontextdb[postgres]"
+            ) from exc
+        try:
+            return await asyncpg.connect(
+                self.config.dsn,
+                ssl=self.config.ssl_mode,
+                timeout=10,
+                command_timeout=30,
+            )
+        except Exception as exc:
+            raise ConnectorSourceError(
+                "PostgreSQL source is unavailable"
+            ) from exc
+
+    async def validate(self) -> None:
+        connection = await self._connect()
+        try:
+            await connection.fetchval(
+                f"SELECT 1 FROM {_relation(self.config.relation)} LIMIT 1"
+            )
+        except Exception as exc:
+            raise ConnectorSourceError(
+                "configured relation is unavailable"
+            ) from exc
+        finally:
+            await connection.close()
+
+    async def preview(self, *, limit: int = 50) -> list[ConnectorRecord]:
+        output: list[ConnectorRecord] = []
+        async for page in self.records(limit=limit):
+            output.extend(page)
+        return output
+
+    async def records(
+        self,
+        *,
+        cursor: ConnectorCursor | None = None,
+        limit: int = 100_000,
+    ) -> AsyncIterator[list[ConnectorRecord]]:
+        if not 1 <= limit <= 1_000_000:
+            raise ConnectorConfigError("limit must be between 1 and 1000000")
+        connection = await self._connect()
+        current = cursor
+        remaining = limit
+        try:
+            while remaining > 0:
+                page_limit = min(self.config.page_size, remaining)
+                rows = await self._fetch_page(
+                    connection,
+                    cursor=current,
+                    limit=page_limit,
+                )
+                if not rows:
+                    break
+                records = [self._record(row) for row in rows]
+                yield records
+                last = records[-1]
+                current = ConnectorCursor(
+                    updated_at=last.updated_at,
+                    primary_key=last.source_key,
+                )
+                remaining -= len(records)
+                if len(records) < page_limit:
+                    break
+        finally:
+            await connection.close()
+
+    async def _fetch_page(
+        self,
+        connection: Any,
+        *,
+        cursor: ConnectorCursor | None,
+        limit: int,
+    ) -> list[Any]:
+        config = self.config
+        relation = _relation(config.relation)
+        primary_key = _quoted(config.primary_key)
+        user_id = _quoted(config.user_id)
+        content = _quoted(config.content)
+        updated_at = _quoted(config.updated_at)
+        deleted_at = (
+            _quoted(config.deleted_at)
+            if config.deleted_at is not None
+            else None
+        )
+        effective_updated = (
+            f"GREATEST({updated_at}, COALESCE({deleted_at}, {updated_at}))"
+            if deleted_at
+            else updated_at
+        )
+        deleted_select = (
+            f"{deleted_at} AS __deleted_at"
+            if deleted_at
+            else "NULL::timestamptz AS __deleted_at"
+        )
+        where = ""
+        params: list[Any] = []
+        if cursor is not None:
+            where = (
+                f"WHERE ({effective_updated} > $1 OR "
+                f"({effective_updated} = $1 AND {primary_key}::text > $2))"
+            )
+            params.extend([cursor.updated_at, cursor.primary_key])
+        params.append(limit)
+        query = f"""
+            SELECT
+                {primary_key}::text AS __source_key,
+                {user_id}::text AS __user_id,
+                {content}::text AS __content,
+                {effective_updated} AS __effective_updated,
+                {deleted_select}
+            FROM {relation}
+            {where}
+            ORDER BY {effective_updated}, {primary_key}::text
+            LIMIT ${len(params)}
+        """
+        try:
+            return list(await connection.fetch(query, *params))
+        except Exception as exc:
+            raise ConnectorSourceError(
+                "failed to read PostgreSQL source"
+            ) from exc
+
+    def _record(self, row: Any) -> ConnectorRecord:
+        updated_at = row["__effective_updated"]
+        if not isinstance(updated_at, datetime):
+            raise ConnectorSourceError(
+                "updated_at mapping must produce a timestamp"
+            )
+        if updated_at.tzinfo is None:
+            updated_at = updated_at.replace(tzinfo=timezone.utc)
+        source_key = str(row["__source_key"])
+        user_id = str(row["__user_id"])
+        content = str(row["__content"] or "")
+        deleted = row["__deleted_at"] is not None
+        if not source_key or not user_id:
+            raise ConnectorSourceError(
+                "source primary key and user_id must be non-empty"
+            )
+        if not deleted and not content:
+            raise ConnectorSourceError(
+                "source content must be non-empty"
+            )
+        return ConnectorRecord(
+            source_key=source_key,
+            source_version=updated_at.isoformat(),
+            user_id=user_id,
+            content=content,
+            updated_at=updated_at,
+            deleted=deleted,
+            provenance={
+                "provider": "postgres",
+                "relation": self.config.relation,
+                "source_key": source_key,
+                "source_version": updated_at.isoformat(),
+            },
+        )

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -1,0 +1,56 @@
+# Connector contracts
+
+ContextDB's public SDK defines a read-only connector contract and a minimal
+PostgreSQL/Supabase reference reader. It deliberately does **not** contain a
+scheduler, credential service, retry queue, managed worker, or hosted sink.
+
+```python
+from contextdb.connectors import (
+    ConnectorCursor,
+    PostgresConnector,
+    PostgresConnectorConfig,
+)
+
+source = PostgresConnector(
+    PostgresConnectorConfig(
+        dsn="postgresql://...",
+        ssl_mode="require",
+        relation="public.customer_context",
+        primary_key="id",
+        user_id="customer_id",
+        content="context_text",
+        updated_at="updated_at",
+        deleted_at="deleted_at",
+    )
+)
+
+await source.validate()
+
+cursor: ConnectorCursor | None = None
+async for page in source.records(cursor=cursor, limit=10_000):
+    for record in page:
+        # The host decides how to form, store, retry, or delete memory.
+        ...
+    if page:
+        last = page[-1]
+        cursor = ConnectorCursor(last.updated_at, last.source_key)
+```
+
+## Required source shape
+
+- A stable primary key.
+- A user-partition column.
+- A content column.
+- An `updated_at` timestamp.
+- Optional `deleted_at` for verifiable soft-delete propagation.
+
+The cursor is `(updated_at, primary_key)`. Timestamp-only cursors can miss rows
+when multiple updates share the same timestamp.
+
+Hard deletes are not discoverable through timestamp polling. Hosts must require
+soft deletes, periodically reconcile the complete key set, or use a CDC
+implementation outside this reference reader.
+
+Credentials are supplied directly by the local host. ContextDB Cloud's managed
+Secret Manager, scheduling, checkpoints, retries, DLQ, monitoring, and
+operational guarantees are private operated capabilities.

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,9 @@ The full walkthrough is in [quickstart.md](quickstart.md). The trust model
 is specified by the evals in `tests/evals/test_trust_model.py` — where
 prose and evals disagree, the evals win.
 
+Source ingestion contracts and the local PostgreSQL/Supabase reference reader
+are documented in [connectors.md](connectors.md).
+
 ## License
 
 Apache 2.0. The SDK and trust evals are fully public; nothing in this

--- a/tests/unit/test_connectors.py
+++ b/tests/unit/test_connectors.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from contextdb.connectors import (
+    ConnectorConfigError,
+    ConnectorCursor,
+    PostgresConnector,
+    PostgresConnectorConfig,
+)
+
+
+def config(**updates: object) -> PostgresConnectorConfig:
+    values = {
+        "dsn": "postgresql://localhost/source",
+        "relation": "public.customer_context",
+        "primary_key": "id",
+        "user_id": "customer_id",
+        "content": "context_text",
+        "updated_at": "updated_at",
+        "deleted_at": "deleted_at",
+        "ssl_mode": "disable",
+    }
+    values.update(updates)
+    return PostgresConnectorConfig(**values)  # type: ignore[arg-type]
+
+
+def test_postgres_connector_rejects_unsafe_identifiers() -> None:
+    with pytest.raises(ConnectorConfigError):
+        PostgresConnector(config(relation="public.users; DROP TABLE users"))
+    with pytest.raises(ConnectorConfigError):
+        PostgresConnector(config(primary_key="id DESC"))
+    with pytest.raises(ConnectorConfigError):
+        PostgresConnector(config(page_size=0))
+
+
+def test_connector_cursor_is_portable() -> None:
+    cursor = ConnectorCursor(
+        updated_at=datetime(2026, 8, 20, tzinfo=timezone.utc),
+        primary_key="customer-1",
+    )
+    assert cursor.as_dict() == {
+        "updated_at": "2026-08-20T00:00:00+00:00",
+        "primary_key": "customer-1",
+    }

--- a/tests/unit/test_postgres_connector.py
+++ b/tests/unit/test_postgres_connector.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime, timezone
+
+import pytest
+
+from contextdb.connectors import (
+    ConnectorCursor,
+    PostgresConnector,
+    PostgresConnectorConfig,
+)
+
+PG_DSN = os.environ.get("CONTEXTDB_TEST_POSTGRES_URL", "")
+pytestmark = pytest.mark.skipif(
+    not PG_DSN,
+    reason="CONTEXTDB_TEST_POSTGRES_URL not set; needs real PostgreSQL",
+)
+
+
+@pytest.mark.asyncio
+async def test_postgres_connector_pages_by_timestamp_and_key() -> None:
+    import asyncpg
+
+    schema = f"connector_{time.time_ns()}"
+    connection = await asyncpg.connect(PG_DSN)
+    await connection.execute(f'CREATE SCHEMA "{schema}"')
+    try:
+        await connection.execute(
+            f"""
+            CREATE TABLE "{schema}".customer_context (
+                id INTEGER PRIMARY KEY,
+                customer_id TEXT NOT NULL,
+                context_text TEXT,
+                updated_at TIMESTAMPTZ NOT NULL,
+                deleted_at TIMESTAMPTZ
+            )
+            """
+        )
+        at = datetime(2026, 8, 20, tzinfo=timezone.utc)
+        await connection.executemany(
+            f"""
+            INSERT INTO "{schema}".customer_context
+            VALUES ($1, $2, $3, $4, $5)
+            """,
+            [
+                (1, "user-1", "Tuesday", at, None),
+                (10, "user-10", "Friday", at, None),
+                (2, "user-2", None, at, at),
+            ],
+        )
+        connector = PostgresConnector(
+            PostgresConnectorConfig(
+                dsn=PG_DSN,
+                relation=f"{schema}.customer_context",
+                primary_key="id",
+                user_id="customer_id",
+                content="context_text",
+                updated_at="updated_at",
+                deleted_at="deleted_at",
+                page_size=2,
+                ssl_mode="disable",
+            )
+        )
+        await connector.validate()
+        preview = await connector.preview()
+        assert [record.source_key for record in preview] == ["1", "10", "2"]
+        assert preview[-1].deleted is True
+        remaining = [
+            record
+            async for page in connector.records(
+                cursor=ConnectorCursor(at, "10"),
+            )
+            for record in page
+        ]
+        assert [record.source_key for record in remaining] == ["2"]
+    finally:
+        await connection.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await connection.close()


### PR DESCRIPTION
## Summary
- define portable connector records, stable timestamp-plus-key cursors, and read-only source protocol
- add a minimal local PostgreSQL/Supabase reader under the existing postgres extra
- support relation/column validation, PII-neutral mapping, bounded paging, and soft-delete markers
- document why scheduling, secrets, retries, writes, and guarantees remain host/Cloud concerns
- add real-Postgres CI coverage

## Open-core classification
- [x] Contract — portable connector schema and cursor semantics, with a minimal single-node reference adapter.

## Why this repository is correct
The reader works offline under host control. It contains no hosted credentials, scheduler, queue, sink, tenancy, monitoring, or operated guarantee.

## Verification
- connector unit tests passed
- Python 3.12 mypy passed across 60 source files
- Ruff and IDE diagnostics passed

Made with [Cursor](https://cursor.com)